### PR TITLE
Changes to `exec`

### DIFF
--- a/javascript/forevervm/src/commands/machine/repl.ts
+++ b/javascript/forevervm/src/commands/machine/repl.ts
@@ -1,7 +1,8 @@
-import { Args, Command } from '@oclif/core'
-import { getSDKFromEnv } from '../../config.js'
-import chalk from 'chalk'
 import { input } from '@inquirer/prompts'
+import { Args, Command } from '@oclif/core'
+import chalk from 'chalk'
+
+import { getSDKFromEnv } from '../../config.js'
 
 export default class MachineRepl extends Command {
   static override args = {
@@ -28,7 +29,7 @@ export default class MachineRepl extends Command {
         continue
       }
 
-      const execResult = await repl.exec({ code })
+      const execResult = await repl.exec(code)
 
       while (true) {
         let output = await execResult.nextOutput()

--- a/javascript/package-lock.json
+++ b/javascript/package-lock.json
@@ -11,7 +11,7 @@
       ]
     },
     "forevervm": {
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "MIT",
       "dependencies": {
         "@forevervm/sdk": "*",
@@ -11470,7 +11470,7 @@
     },
     "sdk": {
       "name": "@forevervm/sdk",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^22.10.7",

--- a/javascript/sdk/src/repl.ts
+++ b/javascript/sdk/src/repl.ts
@@ -2,13 +2,14 @@ import { Stream } from './stream'
 import { ExecResponse } from './types'
 
 export interface ExecOptions {
-  timeout?: number
+  timeoutSeconds?: number
   interrupt?: boolean
 }
 
 export interface Instruction {
   code: string
   max_duration_seconds?: number
+  timeout_seconds?: number
 }
 
 export type MessageToServer = {
@@ -125,7 +126,11 @@ export class ReplClient {
 
   async exec(code: string, options: ExecOptions = {}): Promise<ReplExecResult> {
     const request_id = this.nextRequestId++
-    const instruction = { code, max_runtime_ms: options.timeout }
+    const instruction = {
+      code,
+      max_runtime_ms: options.timeoutSeconds,
+      timeout_seconds: options.timeoutSeconds,
+    }
     const instructionSeq = await new Promise<number>((resolve) => {
       this.state = {
         type: 'waiting_for_instruction_seq',

--- a/javascript/sdk/src/repl.ts
+++ b/javascript/sdk/src/repl.ts
@@ -1,6 +1,11 @@
 import { Stream } from './stream'
 import { ExecResponse } from './types'
 
+export interface ExecOptions {
+  timeout?: number
+  interrupt?: boolean
+}
+
 export interface Instruction {
   code: string
   max_duration_seconds?: number
@@ -104,19 +109,16 @@ export class ReplClient {
     this.ws.send(JSON.stringify(message))
   }
 
-  async exec(instruction: Instruction): Promise<ReplExecResult> {
+  async exec(code: string, options: ExecOptions = {}): Promise<ReplExecResult> {
     const request_id = this.nextRequestId++
+    const instruction = { code, max_runtime_ms: options.timeout }
     const instructionSeq = await new Promise<number>((resolve) => {
       this.state = {
         type: 'waiting_for_instruction_seq',
         request_id,
         callback: resolve,
       }
-      this.send({
-        type: 'exec',
-        instruction,
-        request_id,
-      })
+      this.send({ type: 'exec', instruction, request_id })
     })
 
     const result = new ReplExecResult()


### PR DESCRIPTION
- Change the `exec` function signature to `exec(code: string, options?: { timeout?: number; interrupt?: boolean })`
- Refactor the `recv` method