### PR TITLE
allow creating a new machine, also alias repl command

### DIFF
--- a/javascript/forevervm/src/commands/machine/repl.ts
+++ b/javascript/forevervm/src/commands/machine/repl.ts
@@ -5,8 +5,10 @@ import chalk from 'chalk'
 import { getSDKFromEnv } from '../../config.js'
 
 export default class MachineRepl extends Command {
+  static aliases = ['repl']
+
   static override args = {
-    machine: Args.string({ description: 'machine to connect to', required: true }),
+    machine: Args.string({ description: 'machine to connect to' }),
   }
 
   static override description = 'connect to a machine and start a REPL'
@@ -17,8 +19,13 @@ export default class MachineRepl extends Command {
     const { args } = await this.parse(MachineRepl)
     const sdk = getSDKFromEnv(this.config.configDir)
 
-    const repl = await sdk.repl(args.machine)
-    this.log(`Connected to ${chalk.green(args.machine)}!`)
+    const repl = await sdk.repl(args.machine ?? null)
+
+    if (args.machine) {
+      this.log(`Connected to ${chalk.green(args.machine)}!`)
+    } else {
+      this.log('Connected to new machine!')
+    }
 
     while (true) {
       const code = await input({

--- a/javascript/sdk/src/index.ts
+++ b/javascript/sdk/src/index.ts
@@ -82,10 +82,10 @@ export class ForeverVM {
     return await this.getRequest(`/v1/machine/${machineName}/exec/${instructionSeq}/result`)
   }
 
-  async repl(machineName: string): Promise<ReplClient> {
+  async repl(machineName: string | null): Promise<ReplClient> {
     return new Promise<ReplClient>((resolve, reject) => {
       const ws = new WebSocket(
-        `${this.baseUrl.replace(/^http/, 'ws')}/v1/machine/${machineName}/repl`,
+        `${this.baseUrl.replace(/^http/, 'ws')}/v1/machine/${machineName ?? 'new'}/repl`,
         { headers: { Authorization: `Bearer ${this.token}` } } as any,
       )
 


### PR DESCRIPTION
- allows `forevervm repl` to be used as an alias to `forevervm machine repl`
- if repl is started without a machine ID, creates a new machine