### PR TITLE
Update exec API

### DIFF
--- a/javascript/forevervm/src/commands/machine/repl.ts
+++ b/javascript/forevervm/src/commands/machine/repl.ts
@@ -36,15 +36,13 @@ export default class MachineRepl extends Command {
         continue
       }
 
-      const execResult = await repl.exec(code)
+      const execResult = repl.exec(code)
 
-      while (true) {
-        let output = await execResult.nextOutput()
-        if (output === null) break
-        this.log(chalk.redBright(output.stream), chalk.yellowBright(output.data))
+      for await (const log of execResult.output) {
+        this.log(chalk.redBright(log.stream), chalk.yellowBright(log.data))
       }
 
-      const result = await execResult.result()
+      const result = await execResult.result
       if (result.value !== undefined) {
         this.log(`${chalk.magenta(result.value)}`)
       } else if (result.error !== undefined) {

--- a/javascript/package-lock.json
+++ b/javascript/package-lock.json
@@ -11111,6 +11111,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
       "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11480,7 +11481,7 @@
         "mocha": "^10.0.0",
         "prettier": "^2.0.0",
         "ts-node": "^10.0.0",
-        "typescript": "^4.0.0"
+        "typescript": "^5.7.3"
       }
     },
     "sdk/node_modules/@types/node": {
@@ -11506,19 +11507,6 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
-      }
-    },
-    "sdk/node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
       }
     },
     "sdk/node_modules/undici-types": {

--- a/javascript/sdk/package.json
+++ b/javascript/sdk/package.json
@@ -24,6 +24,6 @@
     "mocha": "^10.0.0",
     "prettier": "^2.0.0",
     "ts-node": "^10.0.0",
-    "typescript": "^4.0.0"
+    "typescript": "^5.7.3"
   }
 }

--- a/javascript/sdk/src/repl.ts
+++ b/javascript/sdk/src/repl.ts
@@ -39,6 +39,11 @@ export type MessageFromServer =
       chunk: StandardOutput
       instruction_id: number
     }
+  | {
+      type: 'error'
+      code: string
+      id: string
+    }
 
 export class ReplClient {
   private ws: WebSocket
@@ -157,6 +162,9 @@ export class ReplExecResult {
         this.#flush()
         this.#resolve(msg.result)
         break
+
+      case 'error':
+        this.#reject(new Error(msg.code))
     }
   }
 }

--- a/javascript/sdk/src/repl.ts
+++ b/javascript/sdk/src/repl.ts
@@ -48,8 +48,8 @@ export class ReplClient {
   constructor(ws: WebSocket) {
     this.ws = ws
     this.ws.addEventListener('message', ({ data }) => {
-      const msg = JSON.parse(data.toString()) as MessageFromServer
-      this.listener.dispatchEvent(new CustomEvent(msg.type, { detail: msg }))
+      const msg = JSON.parse(data.toString())
+      this.listener.dispatchEvent(new CustomEvent('msg', { detail: msg }))
     })
   }
 
@@ -93,9 +93,7 @@ export class ReplExecResult {
   constructor(requestId: number, listener: EventTarget) {
     this.#requestId = requestId
     this.#listener = listener
-    this.#listener.addEventListener('exec_received', this)
-    this.#listener.addEventListener('output', this)
-    this.#listener.addEventListener('result', this)
+    this.#listener.addEventListener('msg', this)
 
     const { promise, resolve, reject } = Promise.withResolvers<ExecResponse>()
     this.result = promise

--- a/javascript/sdk/tsconfig.json
+++ b/javascript/sdk/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2022",
+    "target": "esnext",
     "module": "commonjs",
     "declaration": true,
     "outDir": "./dist",


### PR DESCRIPTION
Large changes to `Repl.exec`.

Externally, the `exec` return type is now this:

```ts
{
  result: Promise<ExecResponse>
  output: AsyncIterable<StandardOutput, undefined>
}
```

This allows people to await the full response and iterate through the output using `for...await`.

Internally, the `Repl` class now uses an `EventTarget` to proxy WebSocket events to an instance of `ReplExecResult`. Most of the state now lives in the `ReplExecResult` class. I think it's simpler but very open to bringing back the `state` object (or other comments/suggestions).