### PR TITLE
Use ws in Node

### DIFF
--- a/javascript/package-lock.json
+++ b/javascript/package-lock.json
@@ -2434,6 +2434,16 @@
       "integrity": "sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g==",
       "dev": true
     },
+    "node_modules/@types/ws": {
+      "version": "8.5.13",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.13.tgz",
+      "integrity": "sha512-osM/gWBTPKgHV8XkTunnegTRIsvF6owmf5w+JtAfOw472dptdm0dlGv4xCt6GwQRcC2XVOvvRE/0bAoQcL2QkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "5.62.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.62.0.tgz",
@@ -11375,6 +11385,27 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
     },
+    "node_modules/ws": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -11484,8 +11515,12 @@
       "name": "@forevervm/sdk",
       "version": "0.1.5",
       "license": "MIT",
+      "dependencies": {
+        "ws": "^8.18.0"
+      },
       "devDependencies": {
         "@types/node": "^22.10.7",
+        "@types/ws": "^8.5.13",
         "@typescript-eslint/eslint-plugin": "^5.0.0",
         "@typescript-eslint/parser": "^5.0.0",
         "eslint": "^8.0.0",

--- a/javascript/sdk/package.json
+++ b/javascript/sdk/package.json
@@ -4,6 +4,9 @@
   "description": "Developer SDK for ForeverVM",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "browser": {
+    "./src/ws.js": "./src/ws.browser.js"
+  },
   "scripts": {
     "build": "tsc",
     "test": "mocha -r ts-node/register 'test/**/*.test.ts'",
@@ -19,6 +22,7 @@
   "license": "MIT",
   "devDependencies": {
     "@types/node": "^22.10.7",
+    "@types/ws": "^8.5.13",
     "@typescript-eslint/eslint-plugin": "^5.0.0",
     "@typescript-eslint/parser": "^5.0.0",
     "eslint": "^8.0.0",
@@ -26,5 +30,8 @@
     "prettier": "^2.0.0",
     "ts-node": "^10.0.0",
     "typescript": "^5.7.3"
+  },
+  "dependencies": {
+    "ws": "^8.18.0"
   }
 }

--- a/javascript/sdk/src/index.ts
+++ b/javascript/sdk/src/index.ts
@@ -6,6 +6,7 @@ import {
   ListMachinesResponse,
   WhoamiResponse,
 } from './types'
+import WebSocket from './ws'
 
 export * from './types'
 export * from './repl'
@@ -93,9 +94,7 @@ export class ForeverVM {
         resolve(new ReplClient(ws))
       })
 
-      ws.addEventListener('error', (error) => {
-        reject(error)
-      })
+      ws.addEventListener('error', reject)
     })
   }
 }

--- a/javascript/sdk/src/repl.ts
+++ b/javascript/sdk/src/repl.ts
@@ -1,4 +1,5 @@
-import { ExecResponse } from './types'
+import type { ExecResponse } from './types'
+import type WebSocket from './ws'
 
 export interface ExecOptions {
   timeoutSeconds?: number

--- a/javascript/sdk/src/ws.browser.ts
+++ b/javascript/sdk/src/ws.browser.ts
@@ -1,0 +1,1 @@
+export default WebSocket

--- a/javascript/sdk/src/ws.ts
+++ b/javascript/sdk/src/ws.ts
@@ -1,0 +1,1 @@
+export { default } from 'ws'


### PR DESCRIPTION
Adds support for Node < 21 with the [`ws`](https://www.npmjs.com/package/ws) library.

Initially I used [`isomorphic-ws`](https://github.com/heineiuo/isomorphic-ws), but if you look at the source it's barely there at all — it basically just uses the `browsers` field in `package.json` to tell the bundler which of two files to load.

I tested this with the forevervm.com repo and it 1. works, and 2. doesn't include `ws` in the browser bundle. There's some weirdness with the type definitions when instantiating directly in a browser, but we can fix that by doing the instantiation in the SDK proper. For now the only browser consumer is ourselves so it's okay to throw an `as any` there for the time being.