### PR TITLE
Update github action dependency

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,10 +26,7 @@ jobs:
         override: true
 
     - name: Build for MacOS
-      uses: actions-rs/cargo@v1
-      with:
-        command: build
-        args: --manifest-path=rust/forevervm/Cargo.toml --bin forevervm --target aarch64-apple-darwin --release
+      run: cargo build --manifest-path=rust/forevervm/Cargo.toml --bin forevervm --target aarch64-apple-darwin --release
 
     - name: strip binary
       run: strip ./rust/target/aarch64-apple-darwin/release/forevervm
@@ -47,18 +44,14 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Install latest rust toolchain
-      uses: actions-rs/toolchain@v1
+      uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
         toolchain: beta
         target: x86_64-apple-darwin
-        default: true
         override: true
 
     - name: Build for MacOS
-      uses: actions-rs/cargo@v1
-      with:
-        command: build
-        args: --release --manifest-path=rust/forevervm/Cargo.toml --bin forevervm --target x86_64-apple-darwin
+      run: cargo build --release --manifest-path=rust/forevervm/Cargo.toml --bin forevervm --target x86_64-apple-darwin
 
     - name: Upload artifact
       uses: actions/upload-artifact@v4
@@ -73,7 +66,7 @@ jobs:
       uses: actions/checkout@v2
       
     - name: Setup Rust
-      uses: actions-rs/toolchain@v1
+      uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
         toolchain: stable
         target: x86_64-unknown-linux-musl
@@ -83,10 +76,7 @@ jobs:
       run: sudo apt-get install -y musl-tools
 
     - name: Build for Linux
-      uses: actions-rs/cargo@v1
-      with:
-        command: build
-        args: --release --target x86_64-unknown-linux-musl --manifest-path=rust/forevervm/Cargo.toml --bin forevervm
+      run: cargo build --release --target x86_64-unknown-linux-musl --manifest-path=rust/forevervm/Cargo.toml --bin forevervm
         
     - name: Upload artifact
       uses: actions/upload-artifact@v4
@@ -99,7 +89,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - uses: actions-rs/toolchain@v1
+    - uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
         toolchain: stable
         target: aarch64-unknown-linux-musl
@@ -111,10 +101,7 @@ jobs:
         sudo apt-get install -y musl-tools gcc-aarch64-linux-gnu musl-dev
 
     - name: Build for Linux
-      uses: actions-rs/cargo@v1
-      with:
-        command: build
-        args: --release --target aarch64-unknown-linux-musl --manifest-path=rust/forevervm/Cargo.toml --bin forevervm
+      run: cargo build --release --target aarch64-unknown-linux-musl --manifest-path=rust/forevervm/Cargo.toml --bin forevervm
   
     - uses: actions/upload-artifact@v4
       with:
@@ -128,7 +115,7 @@ jobs:
       uses: actions/checkout@v2 
 
     - name: Setup Rust
-      uses: actions-rs/toolchain@v1
+      uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
         toolchain: stable
         target: x86_64-pc-windows-gnu
@@ -145,10 +132,7 @@ jobs:
         which nasm
 
     - name: Build for Windows
-      uses: actions-rs/cargo@v1
-      with:
-        command: build
-        args: --release --target x86_64-pc-windows-gnu --manifest-path=rust/forevervm/Cargo.toml --bin forevervm
+      run: cargo build --release --target x86_64-pc-windows-gnu --manifest-path=rust/forevervm/Cargo.toml --bin forevervm
 
     - name: ls
       run: ls ./rust/target/x86_64-pc-windows-gnu/release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,11 +19,10 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Install latest rust toolchain
-      uses: actions-rs/toolchain@v1
+      uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
         toolchain: beta
         target: aarch64-apple-darwin
-        default: true
         override: true
 
     - name: Build for MacOS


### PR DESCRIPTION
Instead of the (archived) [actions-rs/toolchain](https://github.com/actions-rs/toolchain), switch to [actions-rust-lang/setup-rust-toolchain](actions-rust-lang/setup-rust-toolchain)