### PR TITLE
WebSocket reconnect

### DIFF
--- a/javascript/.prettierrc
+++ b/javascript/.prettierrc
@@ -2,5 +2,6 @@
   "singleQuote": true,
   "trailingComma": "all",
   "printWidth": 100,
-  "semi": false
+  "semi": false,
+  "quoteProps": "consistent"
 }

--- a/javascript/sdk/src/index.ts
+++ b/javascript/sdk/src/index.ts
@@ -83,7 +83,7 @@ export class ForeverVM {
     return await this.#get(`/v1/machine/${machineName}/exec/${instructionSeq}/result`)
   }
 
-  async repl(machineName?: string): Promise<Repl> {
+  repl(machineName?: string): Repl {
     return new Repl({
       machine: machineName,
       token: this.#token,

--- a/javascript/sdk/src/index.ts
+++ b/javascript/sdk/src/index.ts
@@ -11,6 +11,7 @@ export * from './types'
 export * from './repl'
 
 interface ForeverVMOptions {
+  token?: string
   baseUrl?: string
 }
 
@@ -18,8 +19,8 @@ export class ForeverVM {
   #token = process.env.FOREVERVM_TOKEN || ''
   #baseUrl = 'https://api.forevervm.com'
 
-  constructor(token: string, options: ForeverVMOptions = {}) {
-    this.#token = token
+  constructor(options: ForeverVMOptions = {}) {
+    if (options.token) this.#token = options.token
     if (options.baseUrl) this.#baseUrl = options.baseUrl
   }
 
@@ -40,7 +41,7 @@ export class ForeverVM {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        Authorization: `Bearer ${this.#token}`,
+        'Authorization': `Bearer ${this.#token}`,
       },
       body: body ? JSON.stringify(body) : undefined,
     })
@@ -83,7 +84,8 @@ export class ForeverVM {
   }
 
   async repl(machineName?: string): Promise<Repl> {
-    return new Repl(machineName, {
+    return new Repl({
+      machine: machineName,
       token: this.#token,
       baseUrl: this.#baseUrl.replace(/^http/, 'ws'),
     })
@@ -97,14 +99,14 @@ if (import.meta.vitest) {
   const FOREVERVM_TOKEN = process.env.FOREVERVM_TOKEN || ''
 
   test('whoami', async () => {
-    const fvm = new ForeverVM(FOREVERVM_TOKEN, { baseUrl: FOREVERVM_API_BASE })
+    const fvm = new ForeverVM({ token: FOREVERVM_TOKEN, baseUrl: FOREVERVM_API_BASE })
 
     const whoami = await fvm.whoami()
     expect(whoami.account).toBeDefined()
   })
 
   test('createMachine and listMachines', async () => {
-    const fvm = new ForeverVM(FOREVERVM_TOKEN, { baseUrl: FOREVERVM_API_BASE })
+    const fvm = new ForeverVM({ token: FOREVERVM_TOKEN, baseUrl: FOREVERVM_API_BASE })
 
     const machine = await fvm.createMachine()
     expect(machine.machine_name).toBeDefined()
@@ -115,7 +117,7 @@ if (import.meta.vitest) {
   })
 
   test('exec and execResult', async () => {
-    const fvm = new ForeverVM(FOREVERVM_TOKEN, { baseUrl: FOREVERVM_API_BASE })
+    const fvm = new ForeverVM({ token: FOREVERVM_TOKEN, baseUrl: FOREVERVM_API_BASE })
     const { machine_name } = await fvm.createMachine()
     const { instruction_seq } = await fvm.exec('print(123) or 567', machine_name)
     expect(instruction_seq).toBe(0)

--- a/javascript/sdk/src/repl.ts
+++ b/javascript/sdk/src/repl.ts
@@ -27,6 +27,10 @@ export type StandardOutput = {
 
 export type MessageFromServer =
   | {
+      type: 'connected'
+      machine_name: string
+    }
+  | {
       type: 'exec_received'
       seq: number // TODO: rename to instruction_id
       request_id: number
@@ -95,8 +99,9 @@ export class Repl {
     this.#ws.addEventListener('close', () => this.#connect())
     this.#ws.addEventListener('error', () => this.#connect())
     this.#ws.addEventListener('message', ({ data }) => {
-      const msg = JSON.parse(data.toString())
-      console.log(msg)
+      const msg = JSON.parse(data.toString()) as MessageFromServer
+      if (msg.type === 'connected') this.#machine = msg.machine_name
+
       this.#listener.dispatchEvent(new CustomEvent('msg', { detail: msg }))
     })
     return this.#ws

--- a/javascript/sdk/src/repl.ts
+++ b/javascript/sdk/src/repl.ts
@@ -302,11 +302,14 @@ if (import.meta.vitest) {
     const repl = new Repl({ token: FOREVERVM_TOKEN, baseUrl: FOREVERVM_API_BASE })
 
     await repl.exec('1 + 1').result
+    const machineName = repl.machineName
 
     ws.close()
 
     const { value, error } = await repl.exec('1 + 1').result
     expect(value).toBe('2')
     expect(error).toBeUndefined()
+
+    expect(repl.machineName).toBe(machineName)
   })
 }

--- a/javascript/sdk/src/repl.ts
+++ b/javascript/sdk/src/repl.ts
@@ -54,6 +54,7 @@ export type MessageFromServer =
 interface ReplOptions {
   baseUrl?: string
   token?: string
+  machine?: string
 }
 
 let createWebsocket = websocket
@@ -61,7 +62,7 @@ let createWebsocket = websocket
 export class Repl {
   #baseUrl = 'wss://api.forevervm.com'
   #token = process.env.FOREVERVM_TOKEN || ''
-  #machine: string | undefined
+  #machine: string | null = null
 
   #ws: WebSocket | NodeWebSocket
   #listener = new EventTarget()
@@ -69,14 +70,10 @@ export class Repl {
   #nextRequestId = 0
   #retries = 0
 
-  constructor(machine?: string, options?: ReplOptions)
-  constructor(options?: ReplOptions)
-  constructor(machine?: string | ReplOptions, options?: ReplOptions) {
-    this.#machine = typeof machine === 'string' ? machine : undefined
-    const opts = (typeof machine === 'string' ? options : machine) ?? {}
-
-    if (opts.token) this.#token = opts.token
-    if (opts.baseUrl) this.#baseUrl = opts.baseUrl
+  constructor(options: ReplOptions = {}) {
+    if (options.token) this.#token = options.token
+    if (options.baseUrl) this.#baseUrl = options.baseUrl
+    if (options.machine) this.#machine = options.machine
 
     if (!this.#token) {
       throw new Error(

--- a/javascript/sdk/src/ws.browser.ts
+++ b/javascript/sdk/src/ws.browser.ts
@@ -1,1 +1,3 @@
-export default WebSocket
+export function websocket(url: string, token: string) {
+  return new WebSocket(url + `?_forevervm_jwt=${token}`)
+}

--- a/javascript/sdk/src/ws.ts
+++ b/javascript/sdk/src/ws.ts
@@ -1,1 +1,5 @@
-export { default } from 'ws'
+import WebSocket from 'ws'
+
+export function websocket(url: string, token: string) {
+  return new WebSocket(url, { headers: { Authorization: `Bearer ${token}` } })
+}

--- a/rust/forevervm-sdk/tests/basic_sdk_tests.rs
+++ b/rust/forevervm-sdk/tests/basic_sdk_tests.rs
@@ -95,6 +95,7 @@ async fn test_repl() {
         .repl(&machine.machine_name)
         .await
         .expect("failed to create REPL");
+    assert_eq!(repl.machine_name, machine.machine_name);
 
     // Execute code that produces multiple outputs
     let code = "for i in range(5):\n  print(i)";


### PR DESCRIPTION
JavaScript/TypeScript SDK:
- Allows the `Repl` to be instantiated directly, using an optional machine name and an optional token (if omitted, reads from the `FOREVERVM_TOKEN` environment variable)
- - Handles `connected` messages from server and sets the machine name if not already set
- Reestablishes the WebSocket connection to the same machine if it's lost, using exponential backoff

Rust SDK:
- Handles `connected` messages from server and sets the machine name