### PR TITLE
fix arm64 linux

### DIFF
--- a/python/forevervm/forevervm/__init__.py
+++ b/python/forevervm/forevervm/__init__.py
@@ -15,7 +15,7 @@ def get_suffix(os_type, os_arch):
     suffixes = {
         ("win32", "x86_64"): "win-x64.exe.gz",
         ("linux", "x86_64"): "linux-x64.gz",
-        ("linux", "arm64"): "linux-arm64.gz",
+        ("linux", "aarch64"): "linux-arm64.gz",
         ("darwin", "x86_64"): "macos-x64.gz",
         ("darwin", "arm64"): "macos-arm64.gz",
     }


### PR DESCRIPTION
On python, our architecture detection code is equivalent to `uname -a`. On Arm Mac, this is reported as `arm64`, but on Linux, this is reported as `aarch64`.

<img width="1064" alt="image" src="https://github.com/user-attachments/assets/7309dbf0-6486-4e85-8d82-c41a52039c4a" />

This does not apply on the javascript side, which is apparently normalized by the node runtime or comes from a different place in the kernel.
