### PR TITLE
Release helpers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -172,6 +172,8 @@ jobs:
       with:
         name: ${{ github.event.inputs.version }}
         draft: true
+        generate_release_notes: true
+        tag_name: v${{ github.event.inputs.version }}
         files: |
             forevervm-win-x64.exe.gz
             forevervm-linux-x64.gz


### PR DESCRIPTION
This should remove a few steps from the release process:

- automatically generates the release notes so we don't have to
- sets the tag name

If this looks good after a few times, we can also remove `draft` and eliminate the manual step.