### PR TITLE
Fix release workflow bug

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -173,7 +173,7 @@ jobs:
         name: ${{ github.event.inputs.version }}
         draft: true
         generate_release_notes: true
-        tag_name: v${{ github.event.inputs.version }}
+        tag_name: ${{ github.event.inputs.version }}
         files: |
             forevervm-win-x64.exe.gz
             forevervm-linux-x64.gz


### PR DESCRIPTION
We are already including the `v` in `github.event.inputs.version`.