### PR TITLE
Fix swallowed runtime exceptions

### DIFF
--- a/javascript/sdk/src/repl.ts
+++ b/javascript/sdk/src/repl.ts
@@ -299,6 +299,14 @@ if (import.meta.vitest) {
     expect(done).toBe(true)
   })
 
+  test.sequential('error', async () => {
+    const repl = new Repl({ baseUrl: FOREVERVM_API_BASE })
+
+    const { value, error } = await repl.exec('1 / 0').result
+    expect(value).toBeUndefined()
+    expect(error).toMatch('ZeroDivisionError')
+  })
+
   test.sequential('reconnect', async () => {
     const repl = new Repl({ token: FOREVERVM_TOKEN, baseUrl: FOREVERVM_API_BASE })
 

--- a/python/sdk/tests/test_connect.py
+++ b/python/sdk/tests/test_connect.py
@@ -40,6 +40,7 @@ def test_repl():
     machine_name = fvm.create_machine()["machine_name"]
     repl = fvm.repl(machine_name)
     assert repl
+
     result = repl.exec("for i in range(5):\n  print(i)")
     output = list(result.output)
     assert output == [
@@ -49,3 +50,7 @@ def test_repl():
         {"data": "3", "stream": "stdout", "seq": 3},
         {"data": "4", "stream": "stdout", "seq": 4},
     ]
+
+    result = repl.exec("1 / 0")
+
+    assert "ZeroDivisionError" in result.result["error"]

--- a/rust/forevervm-sdk/src/api/api_types.rs
+++ b/rust/forevervm-sdk/src/api/api_types.rs
@@ -62,12 +62,14 @@ impl Instruction {
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 #[serde(untagged, rename_all = "snake_case")]
 pub enum ExecResultType {
+    Error {
+        error: String,
+    },
+
     Value {
         value: Option<String>,
         data: Option<serde_json::Value>,
     },
-
-    Error(String),
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]

--- a/rust/forevervm-sdk/tests/basic_sdk_tests.rs
+++ b/rust/forevervm-sdk/tests/basic_sdk_tests.rs
@@ -117,4 +117,16 @@ async fn test_repl() {
         assert_eq!(output.data, i.to_string());
         assert_eq!(output.seq, (i as i64).into());
     }
+
+    // Execute code that results in an error
+    let code = "1 / 0";
+    let exec_result = repl.exec(code).await.expect("failed to execute code");
+
+    let result = exec_result.result().await.unwrap();
+    let ExecResultType::Error { error } = result.result else {
+        panic!("Expected error");
+    };
+
+    assert!(error.contains("ZeroDivisionError"));
+    assert!(error.contains("division by zero"));
 }

--- a/rust/forevervm/src/commands/repl.rs
+++ b/rust/forevervm/src/commands/repl.rs
@@ -34,8 +34,8 @@ pub async fn machine_repl(machine_name: Option<MachineName>) -> anyhow::Result<(
                         let result = result.result().await;
                         match result {
                             Ok(result) => match result.result {
-                                ExecResultType::Error(err) => {
-                                    eprintln!("Error: {}", err);
+                                ExecResultType::Error { error } => {
+                                    eprintln!("Error: {}", error);
                                 }
                                 ExecResultType::Value {
                                     value: Some(value),


### PR DESCRIPTION
Figured out the issue where runtime exceptions were getting swallowed — the `ExecResultType` change made it match the `Value` variant rather than the `Error` variant in that case. We only tested for that on the API side, so it wasn't caught in the tests before merging https://github.com/jamsocket/forevervm/pull/74.

This PR updates the enum so serde can choose the correct variant, and adds test coverage.