### PR TITLE
Don't panic if installing rustls provider fails

### DIFF
--- a/rust/forevervm-sdk/src/client/repl.rs
+++ b/rust/forevervm-sdk/src/client/repl.rs
@@ -180,10 +180,8 @@ async fn receive_loop(
 
 impl ReplConnection {
     pub async fn new(url: reqwest::Url, token: ApiToken) -> Result<Self, ClientError> {
-        // TODO: what is the best practice for this in library code?
-        rustls::crypto::aws_lc_rs::default_provider()
-            .install_default()
-            .expect("Could not install default rustls provider");
+        let _ = rustls::crypto::aws_lc_rs::default_provider()
+            .install_default();
 
         let req = authorized_request(url, token)?;
         let (sender, mut receiver) =

--- a/rust/forevervm-sdk/src/client/repl.rs
+++ b/rust/forevervm-sdk/src/client/repl.rs
@@ -180,8 +180,7 @@ async fn receive_loop(
 
 impl ReplConnection {
     pub async fn new(url: reqwest::Url, token: ApiToken) -> Result<Self, ClientError> {
-        let _ = rustls::crypto::aws_lc_rs::default_provider()
-            .install_default();
+        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
 
         let req = authorized_request(url, token)?;
         let (sender, mut receiver) =


### PR DESCRIPTION
`install_default` will return an error if called twice from the same process ([ref](https://docs.rs/rustls/latest/rustls/crypto/struct.CryptoProvider.html#method.install_default)), which we do not want to promote into a panic. It will only fail in the case that another provider is already installed, in which case we should proceed.