### PR TITLE
v0.1.21 version bump

### DIFF
--- a/javascript/forevervm/package.json
+++ b/javascript/forevervm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "forevervm",
   "description": "CLI for foreverVM",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "author": "Jamsocket",
   "type": "module",
   "bin": {

--- a/javascript/mcp-server/package.json
+++ b/javascript/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forevervm-mcp",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "description": "",
   "main": "index.js",
   "type": "module",

--- a/javascript/package-lock.json
+++ b/javascript/package-lock.json
@@ -29,7 +29,7 @@
       }
     },
     "forevervm": {
-      "version": "0.1.20",
+      "version": "0.1.21",
       "license": "MIT",
       "bin": {
         "forevervm": "src/run.js"
@@ -37,7 +37,7 @@
     },
     "mcp-server": {
       "name": "forevervm-mcp",
-      "version": "0.1.20",
+      "version": "0.1.21",
       "license": "ISC",
       "dependencies": {
         "@forevervm/sdk": "^0.1.20",
@@ -3155,7 +3155,7 @@
     },
     "sdk": {
       "name": "@forevervm/sdk",
-      "version": "0.1.20",
+      "version": "0.1.21",
       "license": "MIT",
       "dependencies": {
         "isomorphic-ws": "^5.0.0",

--- a/javascript/sdk/package.json
+++ b/javascript/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forevervm/sdk",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "description": "Developer SDK for foreverVM",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/python/forevervm/pyproject.toml
+++ b/python/forevervm/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "forevervm"
-version = "0.1.20"
+version = "0.1.21"
 
 [project.scripts]
 forevervm = "forevervm:run_binary"

--- a/python/sdk/pyproject.toml
+++ b/python/sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "forevervm-sdk"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
     "httpx>=0.28.1",
     "httpx-ws>=0.7.1",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -459,7 +459,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "forevervm"
-version = "0.1.19"
+version = "0.1.21"
 dependencies = [
  "anyhow",
  "chrono",
@@ -477,7 +477,7 @@ dependencies = [
 
 [[package]]
 name = "forevervm-sdk"
-version = "0.1.19"
+version = "0.1.21"
 dependencies = [
  "chrono",
  "futures-util",

--- a/rust/forevervm-sdk/Cargo.toml
+++ b/rust/forevervm-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forevervm-sdk"
-version = "0.1.20"
+version = "0.1.21"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 homepage = "https://forevervm.com/"

--- a/rust/forevervm/Cargo.toml
+++ b/rust/forevervm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forevervm"
-version = "0.1.20"
+version = "0.1.21"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 homepage = "https://forevervm.com/"


### PR DESCRIPTION
This release includes the MCP server, and node 18 support which is useful for users of the MCP server.