### PR TITLE
bump to v0.1.22 + fix formatting in README

### DIFF
--- a/javascript/forevervm/package.json
+++ b/javascript/forevervm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "forevervm",
   "description": "CLI for foreverVM",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "author": "Jamsocket",
   "type": "module",
   "bin": {

--- a/javascript/mcp-server/package.json
+++ b/javascript/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forevervm-mcp",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "description": "",
   "main": "index.js",
   "type": "module",

--- a/javascript/package-lock.json
+++ b/javascript/package-lock.json
@@ -29,7 +29,7 @@
       }
     },
     "forevervm": {
-      "version": "0.1.21",
+      "version": "0.1.22",
       "license": "MIT",
       "bin": {
         "forevervm": "src/run.js"
@@ -37,7 +37,7 @@
     },
     "mcp-server": {
       "name": "forevervm-mcp",
-      "version": "0.1.21",
+      "version": "0.1.22",
       "license": "ISC",
       "dependencies": {
         "@forevervm/sdk": "^0.1.20",
@@ -3155,7 +3155,7 @@
     },
     "sdk": {
       "name": "@forevervm/sdk",
-      "version": "0.1.21",
+      "version": "0.1.22",
       "license": "MIT",
       "dependencies": {
         "isomorphic-ws": "^5.0.0",

--- a/javascript/sdk/package.json
+++ b/javascript/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forevervm/sdk",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "description": "Developer SDK for foreverVM",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/python/forevervm/pyproject.toml
+++ b/python/forevervm/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "forevervm"
-version = "0.1.21"
+version = "0.1.22"
 
 [project.scripts]
 forevervm = "forevervm:run_binary"

--- a/python/sdk/pyproject.toml
+++ b/python/sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "forevervm-sdk"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
     "httpx>=0.28.1",
     "httpx-ws>=0.7.1",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -543,7 +543,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "forevervm"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "anyhow",
  "chrono",
@@ -562,7 +562,7 @@ dependencies = [
 
 [[package]]
 name = "forevervm-sdk"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "chrono",
  "futures-util",

--- a/rust/forevervm-sdk/Cargo.toml
+++ b/rust/forevervm-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forevervm-sdk"
-version = "0.1.21"
+version = "0.1.22"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 homepage = "https://forevervm.com/"

--- a/rust/forevervm/Cargo.toml
+++ b/rust/forevervm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forevervm"
-version = "0.1.21"
+version = "0.1.22"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 homepage = "https://forevervm.com/"

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,5 +1,4 @@
-Helper scripts
-==============
+# Helper scripts
 
 - `bump-versions.ts`: Bump the version of all packages in the project.
 


### PR DESCRIPTION
This bumps to `v0.1.22` so we can publish some of the new functionality landed in forevervm-sdk that we want to pull into the api