### PR TITLE
Include runner and SDK info

### DIFF
--- a/javascript/forevervm/src/run.js
+++ b/javascript/forevervm/src/run.js
@@ -6,7 +6,11 @@ import { getBinary } from './get-binary.js'
 async function runBinary() {
   let binpath = await getBinary()
 
-  spawnSync(binpath, process.argv.slice(2), { stdio: 'inherit', stderr: 'inherit' })
+  spawnSync(binpath, process.argv.slice(2), {
+    stdio: 'inherit',
+    stderr: 'inherit',
+    env: { ...process.env, FOREVERVM_RUNNER: 'npx' },
+  })
 }
 
 runBinary()

--- a/javascript/forevervm/src/run.js
+++ b/javascript/forevervm/src/run.js
@@ -9,7 +9,7 @@ async function runBinary() {
   spawnSync(binpath, process.argv.slice(2), {
     stdio: 'inherit',
     stderr: 'inherit',
-    env: { ...process.env, FOREVERVM_RUNNER: 'npx', FOREVERVM_SDK: 'javascript' },
+    env: { ...process.env, FOREVERVM_RUNNER: 'npx' },
   })
 }
 

--- a/javascript/forevervm/src/run.js
+++ b/javascript/forevervm/src/run.js
@@ -9,7 +9,7 @@ async function runBinary() {
   spawnSync(binpath, process.argv.slice(2), {
     stdio: 'inherit',
     stderr: 'inherit',
-    env: { ...process.env, FOREVERVM_RUNNER: 'npx' },
+    env: { ...process.env, FOREVERVM_RUNNER: 'npx', FOREVERVM_SDK: 'javascript' },
   })
 }
 

--- a/javascript/sdk/src/index.ts
+++ b/javascript/sdk/src/index.ts
@@ -24,12 +24,12 @@ export class ForeverVM {
     if (options.baseUrl) this.#baseUrl = options.baseUrl
   }
 
+  get #headers() {
+    return { 'authorization': `Bearer ${this.#token}`, 'x-forevervm-sdk': 'javascript' }
+  }
+
   async #get(path: string) {
-    const response = await fetch(`${this.#baseUrl}${path}`, {
-      headers: {
-        Authorization: `Bearer ${this.#token}`,
-      },
-    })
+    const response = await fetch(`${this.#baseUrl}${path}`, { headers: this.#headers })
     if (!response.ok) {
       throw new Error(`HTTP error! status: ${response.status}`)
     }
@@ -39,10 +39,7 @@ export class ForeverVM {
   async #post(path: string, body?: object) {
     const response = await fetch(`${this.#baseUrl}${path}`, {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'Authorization': `Bearer ${this.#token}`,
-      },
+      headers: { ...this.#headers, 'Content-Type': 'application/json' },
       body: body ? JSON.stringify(body) : undefined,
     })
     if (!response.ok) {

--- a/python/forevervm/forevervm/__init__.py
+++ b/python/forevervm/forevervm/__init__.py
@@ -68,7 +68,11 @@ def get_binary():
 
 def run_binary():
     binpath = get_binary()
-    subprocess.run([binpath] + sys.argv[1:])
+
+    env = os.environ.copy()
+
+    env['FOREVERVM_RUNNER'] = 'uvx'
+    subprocess.run([binpath] + sys.argv[1:], env=env)
 
 
 if __name__ == "__main__":

--- a/python/forevervm/forevervm/__init__.py
+++ b/python/forevervm/forevervm/__init__.py
@@ -72,7 +72,6 @@ def run_binary():
     env = os.environ.copy()
 
     env["FOREVERVM_RUNNER"] = "uvx"
-    env["FOREVERVM_SDK"] = "python"
     subprocess.run([binpath] + sys.argv[1:], env=env)
 
 

--- a/python/forevervm/forevervm/__init__.py
+++ b/python/forevervm/forevervm/__init__.py
@@ -71,7 +71,8 @@ def run_binary():
 
     env = os.environ.copy()
 
-    env['FOREVERVM_RUNNER'] = 'uvx'
+    env["FOREVERVM_RUNNER"] = "uvx"
+    env["FOREVERVM_SDK"] = "python"
     subprocess.run([binpath] + sys.argv[1:], env=env)
 
 

--- a/python/forevervm/uv.lock
+++ b/python/forevervm/uv.lock
@@ -1,7 +1,7 @@
 version = 1
-requires-python = ">=3.12"
+requires-python = ">=3.13"
 
 [[package]]
 name = "forevervm"
-version = "0.1.13"
+version = "0.1.23"
 source = { editable = "." }

--- a/python/sdk/forevervm_sdk/__init__.py
+++ b/python/sdk/forevervm_sdk/__init__.py
@@ -26,7 +26,7 @@ class ForeverVM:
         return f"{self._base_url}{path}"
 
     def _headers(self):
-        return {"authorization": f"Bearer {self._token}"}
+        return {"authorization": f"Bearer {self._token}", "x-forevervm-sdk": "python"}
 
     @property
     def _client(self):

--- a/python/sdk/forevervm_sdk/repl.py
+++ b/python/sdk/forevervm_sdk/repl.py
@@ -82,7 +82,9 @@ class Repl:
         machine_name="new",
         base_url=API_BASE_URL,
     ):
-        client = httpx.Client(headers={"authorization": f"Bearer {token}"})
+        client = httpx.Client(
+            headers={"authorization": f"Bearer {token}", "x-forevervm-sdk": "python"}
+        )
 
         base_url = re.sub(r"^http(s)?://", r"ws\1://", base_url)
 

--- a/rust/forevervm-sdk/src/client/mod.rs
+++ b/rust/forevervm-sdk/src/client/mod.rs
@@ -73,6 +73,7 @@ impl ForeverVMClient {
         let response = self
             .client
             .request(Method::POST, url)
+            .header("x-forevervm-sdk", "rust")
             .bearer_auth(self.token.to_string())
             .json(&request)
             .send()
@@ -90,6 +91,7 @@ impl ForeverVMClient {
         let response = self
             .client
             .request(Method::GET, url)
+            .header("x-forevervm-sdk", "rust")
             .bearer_auth(self.token.to_string())
             .send()
             .await?;

--- a/rust/forevervm-sdk/src/client/util.rs
+++ b/rust/forevervm-sdk/src/client/util.rs
@@ -18,5 +18,6 @@ pub fn authorized_request(url: reqwest::Url, token: ApiToken) -> Result<Request<
         // ref: https://github.com/snapview/tungstenite-rs/blob/c16778797b2eeb118aa064aa5b483f90c3989627/src/client.rs#L240
         .header(SEC_WEBSOCKET_VERSION, "13")
         .header(SEC_WEBSOCKET_KEY, generate_key())
+        .header("x-forevervm-sdk", "rust")
         .body(())?)
 }

--- a/rust/forevervm/src/commands/auth.rs
+++ b/rust/forevervm/src/commands/auth.rs
@@ -71,10 +71,16 @@ pub async fn signup(base_url: Url) -> anyhow::Result<()> {
     let client = Client::new();
     // base_url is always suffixed with a /
     let url = format!("{}internal/signup", base_url);
-    let runner = env::var("FOREVERVM_RUNNER").ok();
     let mut builder = client.post(url);
+
+    let runner = env::var("FOREVERVM_RUNNER").ok();
     if let Some(ref runner) = runner {
         builder = builder.header("x-forevervm-runner", runner);
+    }
+
+    let sdk = env::var("FOREVERVM_SDK").ok();
+    if let Some(ref sdk) = sdk {
+        builder = builder.header("x-forevervm-sdk", sdk);
     }
 
     let response = builder

--- a/rust/forevervm/src/commands/auth.rs
+++ b/rust/forevervm/src/commands/auth.rs
@@ -1,7 +1,4 @@
-use crate::{
-    config::ConfigManager,
-    util::{get_runner, get_sdk},
-};
+use crate::{config::ConfigManager, util::get_runner};
 use colorize::AnsiColor;
 use dialoguer::{theme::ColorfulTheme, Input, Password};
 use forevervm_sdk::{
@@ -73,10 +70,17 @@ pub async fn signup(base_url: Url) -> anyhow::Result<()> {
     // base_url is always suffixed with a /
     let url = format!("{}internal/signup", base_url);
     let runner = get_runner();
+    let sdk = match runner.as_str() {
+        "npx" => "javascript",
+        "uvx" => "python",
+        "cargo" => "rust",
+        _ => "unknown",
+    };
+
     let response = client
         .post(url)
         .header("x-forevervm-runner", &runner)
-        .header("x-forevervm-sdk", get_sdk())
+        .header("x-forevervm-sdk", sdk)
         .json(&ApiSignupRequest {
             email: email.clone(),
             account_name: account_name.clone(),

--- a/rust/forevervm/src/commands/auth.rs
+++ b/rust/forevervm/src/commands/auth.rs
@@ -1,3 +1,5 @@
+use std::env;
+
 use crate::config::ConfigManager;
 use colorize::AnsiColor;
 use dialoguer::{theme::ColorfulTheme, Input, Password};
@@ -69,8 +71,13 @@ pub async fn signup(base_url: Url) -> anyhow::Result<()> {
     let client = Client::new();
     // base_url is always suffixed with a /
     let url = format!("{}internal/signup", base_url);
-    let response = client
-        .post(url)
+    let runner = env::var("FOREVERVM_RUNNER").ok();
+    let mut builder = client.post(url);
+    if let Some(ref runner) = runner {
+        builder = builder.header("x-forevervm-runner", runner);
+    }
+
+    let response = builder
         .json(&ApiSignupRequest {
             email: email.clone(),
             account_name: account_name.clone(),
@@ -79,7 +86,11 @@ pub async fn signup(base_url: Url) -> anyhow::Result<()> {
         .await?;
 
     if response.status().is_success() {
-        let command = "forevervm login".to_string().b_green();
+        let mut command = "forevervm login".to_string().b_green();
+        if let Some(ref runner) = runner {
+            command = format!("{runner} {command}").b_green();
+        }
+
         println!(
             "\nSuccess! Check your email for your API token! Then run {} to log in.\n",
             command

--- a/rust/forevervm/src/main.rs
+++ b/rust/forevervm/src/main.rs
@@ -1,5 +1,7 @@
 #![deny(clippy::unwrap_used)]
 
+use std::env;
+
 use clap::{Parser, Subcommand};
 use forevervm::{
     commands::{
@@ -61,6 +63,15 @@ enum MachineCommands {
 
 async fn main_inner() -> anyhow::Result<()> {
     let cli = Cli::parse();
+
+    env::set_var(
+        "FOREVERVM_RUNNER",
+        env::var("FOREVERVM_RUNNER").unwrap_or_else(|_| "cargo".to_string()),
+    );
+    env::set_var(
+        "FOREVERVM_SDK",
+        env::var("FOREVERVM_SDK").unwrap_or_else(|_| "rust".to_string()),
+    );
 
     match cli.command {
         Commands::Signup { api_base_url } => {

--- a/rust/forevervm/src/main.rs
+++ b/rust/forevervm/src/main.rs
@@ -1,7 +1,5 @@
 #![deny(clippy::unwrap_used)]
 
-use std::env;
-
 use clap::{Parser, Subcommand};
 use forevervm::{
     commands::{
@@ -63,15 +61,6 @@ enum MachineCommands {
 
 async fn main_inner() -> anyhow::Result<()> {
     let cli = Cli::parse();
-
-    env::set_var(
-        "FOREVERVM_RUNNER",
-        env::var("FOREVERVM_RUNNER").unwrap_or_else(|_| "cargo".to_string()),
-    );
-    env::set_var(
-        "FOREVERVM_SDK",
-        env::var("FOREVERVM_SDK").unwrap_or_else(|_| "rust".to_string()),
-    );
 
     match cli.command {
         Commands::Signup { api_base_url } => {

--- a/rust/forevervm/src/util.rs
+++ b/rust/forevervm/src/util.rs
@@ -1,5 +1,5 @@
 use chrono::Duration;
-use std::fmt::Display;
+use std::{env, fmt::Display};
 
 pub enum ApproximateDuration {
     Days(i64),
@@ -39,4 +39,12 @@ impl From<Duration> for ApproximateDuration {
 
         Self::Seconds(duration.num_seconds())
     }
+}
+
+pub fn get_runner() -> String {
+    env::var("FOREVERVM_RUNNER").unwrap_or_else(|_| "cargo".to_string())
+}
+
+pub fn get_sdk() -> String {
+    env::var("FOREVERVM_SDK").unwrap_or_else(|_| "rust".to_string())
 }

--- a/rust/forevervm/src/util.rs
+++ b/rust/forevervm/src/util.rs
@@ -44,7 +44,3 @@ impl From<Duration> for ApproximateDuration {
 pub fn get_runner() -> String {
     env::var("FOREVERVM_RUNNER").unwrap_or_else(|_| "cargo".to_string())
 }
-
-pub fn get_sdk() -> String {
-    env::var("FOREVERVM_SDK").unwrap_or_else(|_| "rust".to_string())
-}


### PR DESCRIPTION
This PR…
- sends info about the runner and language to the API via `x-forevervm-runner` and `x-forevervm-sdk` headers
- includes the runner in the signup prompt (e.g. `npx forevervm login`)