### PR TITLE
Check process exists before reading

### DIFF
--- a/javascript/sdk/src/env.ts
+++ b/javascript/sdk/src/env.ts
@@ -1,0 +1,4 @@
+export let env: { [key: string]: string | undefined } = {}
+
+if (typeof process !== 'undefined') env = process.env
+else if ('env' in import.meta) env = (import.meta as any).env

--- a/javascript/sdk/src/index.ts
+++ b/javascript/sdk/src/index.ts
@@ -1,4 +1,5 @@
 import { Repl } from './repl'
+import { env } from './env'
 import type {
   ApiExecResponse,
   ApiExecResponseResult,
@@ -16,7 +17,7 @@ interface ForeverVMOptions {
 }
 
 export class ForeverVM {
-  #token = process.env.FOREVERVM_TOKEN || ''
+  #token = env.FOREVERVM_TOKEN || ''
   #baseUrl = 'https://api.forevervm.com'
 
   constructor(options: ForeverVMOptions = {}) {

--- a/javascript/sdk/src/repl.ts
+++ b/javascript/sdk/src/repl.ts
@@ -1,3 +1,4 @@
+import { env } from './env'
 import type { ExecResponse } from './types'
 import WebSocket from 'isomorphic-ws'
 
@@ -85,7 +86,7 @@ if (typeof CustomEvent !== 'function') {
 
 export class Repl {
   #baseUrl = 'wss://api.forevervm.com'
-  #token = process.env.FOREVERVM_TOKEN || ''
+  #token = env.FOREVERVM_TOKEN || ''
   #machine: string | null = null
 
   #ws: WebSocket


### PR DESCRIPTION
When using the Repl in Astro I was getting an error that `process` wasn't defined (since it's a Node API). This PR adds an `env.ts` that checks for env vars on `process.env` and `import.meta.env` (which is [where Vite puts them](https://vite.dev/guide/env-and-mode))