### PR TITLE
Improve header logging

### DIFF
--- a/rust/forevervm-sdk/src/client/mod.rs
+++ b/rust/forevervm-sdk/src/client/mod.rs
@@ -1,12 +1,18 @@
-use crate::api::{
-    api_types::{ApiExecRequest, ApiExecResponse, ApiExecResultResponse, Instruction},
-    http_api::{CreateMachineResponse, ListMachinesResponse, WhoamiResponse},
-    id_types::{InstructionSeq, MachineName},
-    token::ApiToken,
+use crate::{
+    api::{
+        api_types::{ApiExecRequest, ApiExecResponse, ApiExecResultResponse, Instruction},
+        http_api::{CreateMachineResponse, ListMachinesResponse, WhoamiResponse},
+        id_types::{InstructionSeq, MachineName},
+        token::ApiToken,
+    },
+    util::get_runner,
 };
 use error::{ClientError, Result};
 use repl::ReplConnection;
-use reqwest::{Client, Method, Response, Url};
+use reqwest::{
+    header::{HeaderMap, HeaderValue},
+    Client, Method, Response, Url,
+};
 use serde::{de::DeserializeOwned, Serialize};
 
 pub mod error;
@@ -44,6 +50,22 @@ impl ForeverVMClient {
         &self.api_base
     }
 
+    fn headers() -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        if let Ok(val) = HeaderValue::from_str("rust") {
+            headers.insert("x-forevervm-sdk", val);
+        }
+
+        let runner = get_runner()
+            .map(|v| HeaderValue::from_str(&v).ok())
+            .flatten();
+        if let Some(val) = runner {
+            headers.insert("x-forevervm-runner", val);
+        }
+
+        headers
+    }
+
     pub async fn repl(&self, machine_name: &MachineName) -> Result<ReplConnection> {
         let mut base_url = self.api_base.clone();
         match base_url.scheme() {
@@ -73,7 +95,7 @@ impl ForeverVMClient {
         let response = self
             .client
             .request(Method::POST, url)
-            .header("x-forevervm-sdk", "rust")
+            .headers(ForeverVMClient::headers())
             .bearer_auth(self.token.to_string())
             .json(&request)
             .send()
@@ -91,7 +113,7 @@ impl ForeverVMClient {
         let response = self
             .client
             .request(Method::GET, url)
-            .header("x-forevervm-sdk", "rust")
+            .headers(ForeverVMClient::headers())
             .bearer_auth(self.token.to_string())
             .send()
             .await?;

--- a/rust/forevervm-sdk/src/client/mod.rs
+++ b/rust/forevervm-sdk/src/client/mod.rs
@@ -52,14 +52,9 @@ impl ForeverVMClient {
 
     fn headers() -> HeaderMap {
         let mut headers = HeaderMap::new();
-        if let Ok(val) = HeaderValue::from_str("rust") {
-            headers.insert("x-forevervm-sdk", val);
-        }
+        headers.insert("x-forevervm-sdk", HeaderValue::from_static("rust"));
 
-        let runner = get_runner()
-            .map(|v| HeaderValue::from_str(&v).ok())
-            .flatten();
-        if let Some(val) = runner {
+        if let Some(val) = get_runner().and_then(|v| HeaderValue::from_str(&v).ok()) {
             headers.insert("x-forevervm-runner", val);
         }
 

--- a/rust/forevervm-sdk/src/util.rs
+++ b/rust/forevervm-sdk/src/util.rs
@@ -1,3 +1,5 @@
+use std::env;
+
 use regex::Regex;
 
 pub fn validate_email(email: &str) -> bool {
@@ -13,4 +15,8 @@ pub fn validate_account_name(account_name: &str) -> bool {
     account_name
         .chars()
         .all(|c| c.is_alphanumeric() || c == '_' || c == '-')
+}
+
+pub fn get_runner() -> Option<String> {
+    env::var("FOREVERVM_RUNNER").ok()
 }


### PR DESCRIPTION
Centralizes the header generation in a `headers` function. Also correctly adds the `x-forevervm-runner` header.