### PR TITLE
Add timeout option to CLI repl

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -497,7 +497,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "forevervm"
-version = "0.1.24"
+version = "0.1.25"
 dependencies = [
  "anyhow",
  "chrono",
@@ -516,7 +516,7 @@ dependencies = [
 
 [[package]]
 name = "forevervm-sdk"
-version = "0.1.24"
+version = "0.1.25"
 dependencies = [
  "chrono",
  "futures-util",


### PR DESCRIPTION
This adds `--instruction-timeout-seconds` as an option for the CLI repl. It also refactors the repl args to share the same struct and code path regardless of whether it is called as `forevervm repl` or `forevervm machine repl`.

Works in prod now:

```
~/projects/forevervm/rust/forevervm # cargo run repl --instruction-timeout-seconds 45
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.07s
     Running `/Users/paul/projects/forevervm/rust/target/debug/forevervm repl --instruction-timeout-seconds 45`
Connected to 7pLrjm4W25Sw5wEU
>>> from time import sleep
>>> sleep(40); print(3)
3
>>> 
Error: EOF
~/projects/forevervm/rust/forevervm # cargo run repl                                 
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.07s
     Running `/Users/paul/projects/forevervm/rust/target/debug/forevervm repl`
Connected to nqpxwYqFcVnd2KcC
>>> from time import sleep
>>> sleep(40); print(3)
Error: Timed out
```