### PR TITLE
Support timeout in Python SDK

### DIFF
--- a/python/sdk/forevervm_sdk/repl.py
+++ b/python/sdk/forevervm_sdk/repl.py
@@ -8,6 +8,8 @@ from httpx_ws import WebSocketSession, connect_ws
 from .config import API_BASE_URL
 from .types import ExecResult, StandardOutput
 
+DEFAULT_INSTRUCTION_TIMEOUT_SECONDS = 15
+
 
 class ReplException(Exception):
     pass
@@ -102,14 +104,16 @@ class Repl:
     def __exit__(self, type, value, traceback):
         self._connection.__exit__(type, value, traceback)
 
-    def exec(self, code: str) -> ReplExecResult:
+    def exec(
+        self, code: str, timeout_seconds: int = DEFAULT_INSTRUCTION_TIMEOUT_SECONDS
+    ) -> ReplExecResult:
         if self._instruction is not None and self._instruction._result is None:
             raise ReplException("Instruction already running")
 
         request_id = self._request_id
         self._request_id += 1
 
-        instruction = {"code": code}
+        instruction = {"code": code, "timeout_seconds": timeout_seconds}
         self._ws.send_json(
             {"type": "exec", "instruction": instruction, "request_id": request_id}
         )

--- a/python/sdk/tests/test_connect.py
+++ b/python/sdk/tests/test_connect.py
@@ -64,3 +64,23 @@ def test_repl():
     result = repl.exec("1 / 0")
 
     assert "ZeroDivisionError" in result.result["error"]
+
+
+def test_repl_timeout():
+    fvm = ForeverVM(FOREVERVM_TOKEN, base_url=FOREVERVM_API_BASE)
+    machine_name = fvm.create_machine()["machine_name"]
+    repl = fvm.repl(machine_name)
+    assert repl
+
+    result = repl.exec("from time import sleep")
+    result.result
+
+    result = repl.exec("sleep(10)", timeout_seconds=1)
+    assert "Timed out" in result.result["error"]
+
+    result = repl.exec("sleep(1); print('done')", timeout_seconds=5)
+    output = list(result.output)
+    assert output == [
+        {"data": "done", "stream": "stdout", "seq": 0},
+    ]
+    result.result

--- a/python/sdk/uv.lock
+++ b/python/sdk/uv.lock
@@ -34,7 +34,7 @@ wheels = [
 
 [[package]]
 name = "forevervm-sdk"
-version = "0.1.22"
+version = "0.1.25"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
This supports an additional, optional, `timeout_seconds` parameter to `exec`. This supplies a timeout (in seconds) that overrides the default of 15s.