### PR TITLE
Check binary files before publish

### DIFF
--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -2,6 +2,7 @@ import * as cp from 'node:child_process'
 import path from 'node:path'
 import readline from 'node:readline/promises'
 import * as fs from 'node:fs'
+import { fileURLToPath } from 'url'
 
 const rl = readline.createInterface({ input: process.stdin, output: process.stdout })
 let abort = new AbortController()
@@ -28,7 +29,13 @@ function exec(command: string, options?: cp.ExecOptions & { log?: boolean }) {
 }
 
 function getVersion() {
-  const currentScriptPath = path.join(path.dirname(__filename), '..', 'javascript', 'forevervm', 'package.json')
+  const currentScriptPath = path.join(
+    path.dirname(fileURLToPath(import.meta.url)),
+    '..',
+    'javascript',
+    'forevervm',
+    'package.json',
+  )
   const json = JSON.parse(fs.readFileSync(currentScriptPath, 'utf-8'))
   return json.version
 }

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -28,6 +28,9 @@ function exec(command: string, options?: cp.ExecOptions & { log?: boolean }) {
   })
 }
 
+/** Get the version number being deployed. Arbitrarily uses the forevervm npm package;
+ * All packages should be in sync but this is not tested.
+ */
 function getVersion() {
   const currentScriptPath = path.join(
     path.dirname(fileURLToPath(import.meta.url)),
@@ -40,6 +43,7 @@ function getVersion() {
   return json.version
 }
 
+/** Verify that all binary files exist for the given version. */
 async function verifyBinariesExist(version: string) {
   const files = [
     'win-x64.exe.gz',


### PR DESCRIPTION
This ensures that binary files matching the URLs used by download scripts exist for the version we are publishing.