### PR TITLE
Add installer for Windsurf & Goose MCP servers

### DIFF
--- a/javascript/mcp-server/package.json
+++ b/javascript/mcp-server/package.json
@@ -27,6 +27,7 @@
     "commander": "^13.1.0",
     "prettier": "^3.4.2",
     "shx": "^0.3.4",
+    "yaml": "^2.7.0",
     "zod": "^3.24.1"
   },
   "devDependencies": {

--- a/javascript/mcp-server/src/index.ts
+++ b/javascript/mcp-server/src/index.ts
@@ -13,7 +13,7 @@ import { installForClaude } from './install/claude.js'
 import { installForWindsurf } from './install/windsurf.js'
 import { installForGoose } from './install/goose.js'
 
-async function installForeverVM(options: { claude: boolean; windsurf: boolean; goose: boolean }) {
+function installForeverVM(options: { claude: boolean; windsurf: boolean; goose: boolean }) {
   let forevervmToken = getForeverVMToken()
 
   if (!forevervmToken) {

--- a/javascript/mcp-server/src/index.ts
+++ b/javascript/mcp-server/src/index.ts
@@ -11,8 +11,9 @@ import os from 'os'
 import { Command } from 'commander'
 import { installForClaude } from './install/claude.js'
 import { installForWindsurf } from './install/windsurf.js'
+import { installForGoose } from './install/goose.js'
 
-async function installForeverVM(options: { claude: boolean; windsurf: boolean }) {
+async function installForeverVM(options: { claude: boolean; windsurf: boolean; goose: boolean }) {
   let forevervmToken = getForeverVMToken()
 
   if (!forevervmToken) {
@@ -22,16 +23,19 @@ async function installForeverVM(options: { claude: boolean; windsurf: boolean })
     process.exit(1)
   }
 
-  console.log('o', options)
-  if (!options.claude && !options.windsurf) {
+  if (!options.claude && !options.windsurf && !options.goose) {
     console.log(
-      'Select at least one MCP client to install. Available options: --claude, --windsurf',
+      'Select at least one MCP client to install. Available options: --claude, --windsurf, --goose',
     )
     process.exit(1)
   }
 
   if (options.claude) {
     installForClaude()
+  }
+
+  if (options.goose) {
+    installForGoose()
   }
 
   if (options.windsurf) {
@@ -286,6 +290,7 @@ function main() {
     .command('install')
     .description('Set up the ForeverVM MCP server')
     .option('-c, --claude', 'Set up the MCP Server for Claude Desktop')
+    .option('-g, --goose', 'Set up the MCP Server for Codename Goose (CLI only)')
     .option('-w, --windsurf', 'Set up the MCP Server for Windsurf')
     .action(installForeverVM)
 

--- a/javascript/mcp-server/src/install/claude.ts
+++ b/javascript/mcp-server/src/install/claude.ts
@@ -1,0 +1,66 @@
+import path from 'path'
+import os from 'os'
+import fs from 'fs'
+
+function getClaudeConfigFilePath(): string {
+  const homeDir = os.homedir()
+
+  if (process.platform === 'win32') {
+    // Windows path
+    return path.join(
+      process.env.APPDATA || path.join(homeDir, 'AppData', 'Roaming'),
+      'Claude',
+      'claude_desktop_config.json',
+    )
+  } else {
+    // macOS & Linux path
+    return path.join(
+      homeDir,
+      'Library',
+      'Application Support',
+      'Claude',
+      'claude_desktop_config.json',
+    )
+  }
+}
+
+export function installForClaude() {
+  const configFilePath = getClaudeConfigFilePath()
+
+  // Ensure the parent directory exists
+  const configDir = path.dirname(configFilePath)
+  if (!fs.existsSync(configDir)) {
+    console.error(
+      `Claude config directory does not exist (tried ${configDir}). Unable to install ForeverVM for Claude Desktop.`,
+    )
+    process.exit(1)
+  }
+
+  let config: any = {}
+
+  // If the file exists, read and parse the existing config
+  if (fs.existsSync(configFilePath)) {
+    try {
+      const fileContent = fs.readFileSync(configFilePath, 'utf8')
+      config = JSON.parse(fileContent)
+    } catch (error) {
+      console.error('Failed to read or parse existing Claude config:', error)
+      process.exit(1)
+    }
+  }
+
+  config.mcpServers = config.mcpServers || {}
+
+  config.mcpServers.forevervm = {
+    command: 'npx',
+    args: ['--yes', 'forevervm-mcp', 'run'],
+  }
+
+  try {
+    fs.writeFileSync(configFilePath, JSON.stringify(config, null, 2) + '\n', 'utf8')
+    console.log(`✅ Claude Desktop configuration updated successfully at: ${configFilePath}`)
+  } catch (error) {
+    console.error('❌ Failed to write to Claude Desktop config file:', error)
+    process.exit(1)
+  }
+}

--- a/javascript/mcp-server/src/install/goose.ts
+++ b/javascript/mcp-server/src/install/goose.ts
@@ -1,0 +1,64 @@
+import path from 'path'
+import os from 'os'
+import fs from 'fs'
+import YAML from 'yaml'
+
+function getGooseConfigFilePath(): string {
+  // Goose calls MCP servers "extensions"
+  // Ref: https://block.github.io/goose/docs/getting-started/using-extensions
+  // Currently, only CLI Goose uses file-based configuration; desktop Goose uses
+  // Electron Local Storage. This is actively in transition
+  // Ref: https://github.com/block/goose/discussions/890#discussioncomment-12093422
+  const homeDir = os.homedir()
+
+  return path.join(homeDir, '.config', 'goose', 'config.yaml')
+}
+
+export function installForGoose() {
+  const configFilePath = getGooseConfigFilePath()
+
+  // Ensure the parent directory exists
+  const configDir = path.dirname(configFilePath)
+  if (!fs.existsSync(configDir)) {
+    console.error(
+      `Goose config directory does not exist (tried ${configDir}). Unable to install ForeverVM for Goose.`,
+    )
+    process.exit(1)
+  }
+
+  let config: YAML.Document
+  // If the file exists, read and parse the existing config
+  if (fs.existsSync(configFilePath)) {
+    try {
+      const fileContent = fs.readFileSync(configFilePath, 'utf8')
+      config = YAML.parseDocument(fileContent)
+    } catch (error) {
+      console.error('Failed to read or parse existing Goose config:', error)
+      process.exit(1)
+    }
+  } else {
+    console.error(`Goose config file not found at: ${configFilePath}`)
+    process.exit(1)
+  }
+
+  if (!config.has('extensions')) {
+    config.set('extensions', {})
+  }
+
+  config.setIn(['extensions', 'forevervm'], {
+    cmd: 'npx',
+    args: ['--yes', 'forevervm-mcp', 'run'],
+    enabled: true,
+    envs: {},
+    name: 'forevervm',
+    type: 'stdio',
+  })
+
+  try {
+    fs.writeFileSync(configFilePath, YAML.stringify(config), 'utf8')
+    console.log(`✅ Goose configuration updated successfully at: ${configFilePath}`)
+  } catch (error) {
+    console.error('❌ Failed to write to Goose config file:', error)
+    process.exit(1)
+  }
+}

--- a/javascript/mcp-server/src/install/windsurf.ts
+++ b/javascript/mcp-server/src/install/windsurf.ts
@@ -1,0 +1,52 @@
+import path from 'path'
+import os from 'os'
+import fs from 'fs'
+
+function getWindsurfConfigFilePath(): string {
+  // Ref: https://docs.codeium.com/windsurf/mcp
+  // NOTE: the official docs don't say where to put the file on Windows, so currently we don't support that.
+  const homeDir = os.homedir()
+
+  return path.join(homeDir, '.codeium', 'windsurf', 'mcp_config.json')
+}
+
+export function installForWindsurf() {
+  const configFilePath = getWindsurfConfigFilePath()
+
+  // Ensure the parent directory exists
+  const configDir = path.dirname(configFilePath)
+  if (!fs.existsSync(configDir)) {
+    console.error(
+      `Windsurf config directory does not exist (tried ${configDir}). Unable to install ForeverVM for Windsurf.`,
+    )
+    process.exit(1)
+  }
+
+  let config: any = {}
+
+  // If the file exists, read and parse the existing config
+  if (fs.existsSync(configFilePath)) {
+    try {
+      const fileContent = fs.readFileSync(configFilePath, 'utf8')
+      config = JSON.parse(fileContent)
+    } catch (error) {
+      console.error('Failed to read or parse existing Claude config:', error)
+      process.exit(1)
+    }
+  }
+
+  config.mcpServers = config.mcpServers || {}
+
+  config.mcpServers.forevervm = {
+    command: 'npx',
+    args: ['--yes', 'forevervm-mcp', 'run'],
+  }
+
+  try {
+    fs.writeFileSync(configFilePath, JSON.stringify(config, null, 2) + '\n', 'utf8')
+    console.log(`✅ Windsurf configuration updated successfully at: ${configFilePath}`)
+  } catch (error) {
+    console.error('❌ Failed to write to Windsurf config file:', error)
+    process.exit(1)
+  }
+}

--- a/javascript/mcp-server/src/install/windsurf.ts
+++ b/javascript/mcp-server/src/install/windsurf.ts
@@ -30,7 +30,7 @@ export function installForWindsurf() {
       const fileContent = fs.readFileSync(configFilePath, 'utf8')
       config = JSON.parse(fileContent)
     } catch (error) {
-      console.error('Failed to read or parse existing Claude config:', error)
+      console.error('Failed to read or parse existing Windsurf config:', error)
       process.exit(1)
     }
   }

--- a/javascript/mcp-server/src/install/windsurf.ts
+++ b/javascript/mcp-server/src/install/windsurf.ts
@@ -4,8 +4,15 @@ import fs from 'fs'
 
 function getWindsurfConfigFilePath(): string {
   // Ref: https://docs.codeium.com/windsurf/mcp
-  // NOTE: the official docs don't say where to put the file on Windows, so currently we don't support that.
   const homeDir = os.homedir()
+
+  if (process.platform === 'win32') {
+    // NOTE: the official docs don't say where to put the file on Windows, so currently we don't support that.
+    console.error(
+      'Automatic installation is not supported on Windows, follow the instructions here instead: https://docs.codeium.com/windsurf/mcp',
+    )
+    process.exit(1)
+  }
 
   return path.join(homeDir, '.codeium', 'windsurf', 'mcp_config.json')
 }

--- a/javascript/package-lock.json
+++ b/javascript/package-lock.json
@@ -35,6 +35,7 @@
         "commander": "^13.1.0",
         "prettier": "^3.4.2",
         "shx": "^0.3.4",
+        "yaml": "^2.7.0",
         "zod": "^3.24.1"
       },
       "bin": {
@@ -3199,6 +3200,18 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.0.tgz",
+      "integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/zod": {


### PR DESCRIPTION
Currently we support `npx forevervm-mcp --claude`. This adds installer options for `--windsurf` and `--goose`.

Cursor does not seem to expose the configuration and it needs to be done through a UI. Goose only works for the CLI for now, but they are working towards converging the desktop app with the CLI config.

It might be worth turning this into an open source `mcp-install` package!