### PR TITLE
Add timeout option to Python SDK

### DIFF
--- a/python/sdk/forevervm_sdk/types.py
+++ b/python/sdk/forevervm_sdk/types.py
@@ -1,6 +1,10 @@
 from typing import Any, Dict, List, Literal, Optional, TypedDict
 
 
+class RequestOptions(TypedDict, total=False):
+    timeout: int
+
+
 class WhoamiResponse(TypedDict):
     account: str
 

--- a/python/sdk/uv.lock
+++ b/python/sdk/uv.lock
@@ -34,7 +34,7 @@ wheels = [
 
 [[package]]
 name = "forevervm-sdk"
-version = "0.1.26"
+version = "0.1.28"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
~~Adds timeout to Python SDK via the keyword argument `timeout`, which accepts either an int or an [httpx Timeout object](https://www.python-httpx.org/advanced/timeouts/).~~

~~The only method missing it is `exec` — it's a little weird there because we already have `timeout_seconds` which controls the timeout of the _running Python instruction_ (I've renamed that to `instruction_timeout_seconds` to better match) and also because we wrap two separate API requests with that one command. Open to suggestions on how to include it there too!~~

Increases the timeout of `exec_result` and `exec_result_async` to 20 minutes, which is longer than users can set the instruction timeout.