### PR TITLE
Tag support

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -497,7 +497,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "forevervm"
-version = "0.1.29"
+version = "0.1.30"
 dependencies = [
  "anyhow",
  "chrono",
@@ -516,7 +516,7 @@ dependencies = [
 
 [[package]]
 name = "forevervm-sdk"
-version = "0.1.29"
+version = "0.1.30"
 dependencies = [
  "chrono",
  "futures-util",

--- a/rust/forevervm-sdk/src/api/http_api.rs
+++ b/rust/forevervm-sdk/src/api/http_api.rs
@@ -1,5 +1,6 @@
 use super::{api_types::ApiMachine, id_types::MachineName};
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 #[derive(Serialize, Deserialize)]
 pub struct WhoamiResponse {
@@ -14,4 +15,14 @@ pub struct CreateMachineResponse {
 #[derive(Serialize, Deserialize)]
 pub struct ListMachinesResponse {
     pub machines: Vec<ApiMachine>,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct CreateMachineRequest {
+    tags: HashMap<String, String>,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct ListMachinesRequest {
+    tags: HashMap<String, String>,
 }

--- a/rust/forevervm-sdk/src/api/http_api.rs
+++ b/rust/forevervm-sdk/src/api/http_api.rs
@@ -19,10 +19,10 @@ pub struct ListMachinesResponse {
 
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub struct CreateMachineRequest {
-    tags: HashMap<String, String>,
+    pub tags: HashMap<String, String>,
 }
 
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub struct ListMachinesRequest {
-    tags: HashMap<String, String>,
+    pub tags: HashMap<String, String>,
 }

--- a/rust/forevervm-sdk/src/client/mod.rs
+++ b/rust/forevervm-sdk/src/client/mod.rs
@@ -1,7 +1,10 @@
 use crate::{
     api::{
         api_types::{ApiExecRequest, ApiExecResponse, ApiExecResultResponse, Instruction},
-        http_api::{CreateMachineResponse, ListMachinesResponse, WhoamiResponse},
+        http_api::{
+            CreateMachineRequest, CreateMachineResponse, ListMachinesRequest, ListMachinesResponse,
+            WhoamiResponse,
+        },
         id_types::{InstructionSeq, MachineName},
         protocol::MessageFromServer,
         token::ApiToken,
@@ -15,8 +18,8 @@ use reqwest::{
     header::{HeaderMap, HeaderValue},
     Client, Method, Response, Url,
 };
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
-use std::{collections::HashMap, pin::Pin};
+use serde::{de::DeserializeOwned, Serialize};
+use std::pin::Pin;
 
 pub mod error;
 pub mod repl;
@@ -38,16 +41,6 @@ async fn parse_error(response: Response) -> Result<ClientError> {
     } else {
         Err(ClientError::ServerResponseError { code, message })
     }
-}
-
-#[derive(Debug, Default, Serialize, Deserialize)]
-pub struct CreateMachineOptions {
-    tags: HashMap<String, String>,
-}
-
-#[derive(Debug, Default, Serialize, Deserialize)]
-pub struct ListMachinesOptions {
-    tags: HashMap<String, String>,
 }
 
 impl ForeverVMClient {
@@ -135,14 +128,14 @@ impl ForeverVMClient {
 
     pub async fn create_machine(
         &self,
-        options: CreateMachineOptions,
+        options: CreateMachineRequest,
     ) -> Result<CreateMachineResponse> {
         self.post_request("/machine/new", options).await
     }
 
     pub async fn list_machines(
         &self,
-        options: ListMachinesOptions,
+        options: ListMachinesRequest,
     ) -> Result<ListMachinesResponse> {
         self.post_request("/machine/list", options).await
     }

--- a/rust/forevervm-sdk/src/client/mod.rs
+++ b/rust/forevervm-sdk/src/client/mod.rs
@@ -1,5 +1,3 @@
-use std::pin::Pin;
-
 use crate::{
     api::{
         api_types::{ApiExecRequest, ApiExecResponse, ApiExecResultResponse, Instruction},
@@ -17,7 +15,8 @@ use reqwest::{
     header::{HeaderMap, HeaderValue},
     Client, Method, Response, Url,
 };
-use serde::{de::DeserializeOwned, Serialize};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use std::{collections::HashMap, pin::Pin};
 
 pub mod error;
 pub mod repl;
@@ -39,6 +38,16 @@ async fn parse_error(response: Response) -> Result<ClientError> {
     } else {
         Err(ClientError::ServerResponseError { code, message })
     }
+}
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct CreateMachineOptions {
+    tags: HashMap<String, String>,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct ListMachinesOptions {
+    tags: HashMap<String, String>,
 }
 
 impl ForeverVMClient {
@@ -124,12 +133,18 @@ impl ForeverVMClient {
         Ok(response.json().await?)
     }
 
-    pub async fn create_machine(&self) -> Result<CreateMachineResponse> {
-        self.post_request("/machine/new", ()).await
+    pub async fn create_machine(
+        &self,
+        options: CreateMachineOptions,
+    ) -> Result<CreateMachineResponse> {
+        self.post_request("/machine/new", options).await
     }
 
-    pub async fn list_machines(&self) -> Result<ListMachinesResponse> {
-        self.get_request("/machine/list").await
+    pub async fn list_machines(
+        &self,
+        options: ListMachinesOptions,
+    ) -> Result<ListMachinesResponse> {
+        self.post_request("/machine/list", options).await
     }
 
     pub async fn exec_instruction(

--- a/rust/forevervm-sdk/src/client/repl.rs
+++ b/rust/forevervm-sdk/src/client/repl.rs
@@ -1,14 +1,13 @@
+use super::{
+    typed_socket::{websocket_connect, WebSocketRecv, WebSocketSend},
+    util::authorized_request,
+    ClientError,
+};
 use crate::api::{
     api_types::{ExecResult, Instruction},
     id_types::{InstructionSeq, MachineName, RequestSeq},
     protocol::{MessageFromServer, MessageToServer, StandardOutput},
     token::ApiToken,
-};
-
-use super::{
-    typed_socket::{websocket_connect, WebSocketRecv, WebSocketSend},
-    util::authorized_request,
-    ClientError,
 };
 use std::{
     ops::{Deref, DerefMut},

--- a/rust/forevervm-sdk/tests/basic_sdk_tests.rs
+++ b/rust/forevervm-sdk/tests/basic_sdk_tests.rs
@@ -1,5 +1,5 @@
 use forevervm_sdk::api::api_types::Instruction;
-use forevervm_sdk::client::{CreateMachineOptions, ListMachinesOptions};
+use forevervm_sdk::api::http_api::{CreateMachineRequest, ListMachinesRequest};
 use forevervm_sdk::{
     api::{api_types::ExecResultType, protocol::StandardOutputStream, token::ApiToken},
     client::ForeverVMClient,
@@ -33,7 +33,7 @@ async fn test_create_machine() {
 
     // Create a new machine
     let machine = client
-        .create_machine(CreateMachineOptions::default())
+        .create_machine(CreateMachineRequest::default())
         .await
         .expect("failed to create machine");
     let machine_name = machine.machine_name;
@@ -41,7 +41,7 @@ async fn test_create_machine() {
 
     // Verify machine appears in list
     let machines = client
-        .list_machines(ListMachinesOptions::default())
+        .list_machines(ListMachinesRequest::default())
         .await
         .expect("failed to list machines");
     assert!(machines.machines.iter().any(|m| m.name == machine_name));
@@ -54,7 +54,7 @@ async fn test_exec() {
 
     // Create machine and execute code
     let machine = client
-        .create_machine(CreateMachineOptions::default())
+        .create_machine(CreateMachineRequest::default())
         .await
         .expect("failed to create machine");
     let code = "print(123) or 567";
@@ -92,7 +92,7 @@ async fn test_repl() {
 
     // Create machine and get REPL
     let machine = client
-        .create_machine(CreateMachineOptions::default())
+        .create_machine(CreateMachineRequest::default())
         .await
         .expect("failed to create machine");
     let mut repl = client

--- a/rust/forevervm-sdk/tests/basic_sdk_tests.rs
+++ b/rust/forevervm-sdk/tests/basic_sdk_tests.rs
@@ -1,4 +1,5 @@
 use forevervm_sdk::api::api_types::Instruction;
+use forevervm_sdk::client::{CreateMachineOptions, ListMachinesOptions};
 use forevervm_sdk::{
     api::{api_types::ExecResultType, protocol::StandardOutputStream, token::ApiToken},
     client::ForeverVMClient,
@@ -32,7 +33,7 @@ async fn test_create_machine() {
 
     // Create a new machine
     let machine = client
-        .create_machine()
+        .create_machine(CreateMachineOptions::default())
         .await
         .expect("failed to create machine");
     let machine_name = machine.machine_name;
@@ -40,7 +41,7 @@ async fn test_create_machine() {
 
     // Verify machine appears in list
     let machines = client
-        .list_machines()
+        .list_machines(ListMachinesOptions::default())
         .await
         .expect("failed to list machines");
     assert!(machines.machines.iter().any(|m| m.name == machine_name));
@@ -53,7 +54,7 @@ async fn test_exec() {
 
     // Create machine and execute code
     let machine = client
-        .create_machine()
+        .create_machine(CreateMachineOptions::default())
         .await
         .expect("failed to create machine");
     let code = "print(123) or 567";
@@ -91,7 +92,7 @@ async fn test_repl() {
 
     // Create machine and get REPL
     let machine = client
-        .create_machine()
+        .create_machine(CreateMachineOptions::default())
         .await
         .expect("failed to create machine");
     let mut repl = client

--- a/rust/forevervm/src/commands/machine.rs
+++ b/rust/forevervm/src/commands/machine.rs
@@ -1,10 +1,11 @@
 use crate::{config::ConfigManager, util::ApproximateDuration};
 use chrono::Utc;
 use colorize::AnsiColor;
+use forevervm_sdk::client::{CreateMachineOptions, ListMachinesOptions};
 
 pub async fn machine_list() -> anyhow::Result<()> {
     let client = ConfigManager::new()?.client()?;
-    let machines = client.list_machines().await?;
+    let machines = client.list_machines(ListMachinesOptions::default()).await?;
 
     println!("Machines:");
     for machine in machines.machines {
@@ -40,7 +41,9 @@ pub async fn machine_list() -> anyhow::Result<()> {
 pub async fn machine_new() -> anyhow::Result<()> {
     let client = ConfigManager::new()?.client()?;
 
-    let machine = client.create_machine().await?;
+    let machine = client
+        .create_machine(CreateMachineOptions::default())
+        .await?;
 
     println!(
         "Created machine {}",

--- a/rust/forevervm/src/commands/machine.rs
+++ b/rust/forevervm/src/commands/machine.rs
@@ -1,11 +1,11 @@
 use crate::{config::ConfigManager, util::ApproximateDuration};
 use chrono::Utc;
 use colorize::AnsiColor;
-use forevervm_sdk::client::{CreateMachineOptions, ListMachinesOptions};
+use forevervm_sdk::api::http_api::{CreateMachineRequest, ListMachinesRequest};
 
 pub async fn machine_list() -> anyhow::Result<()> {
     let client = ConfigManager::new()?.client()?;
-    let machines = client.list_machines(ListMachinesOptions::default()).await?;
+    let machines = client.list_machines(ListMachinesRequest::default()).await?;
 
     println!("Machines:");
     for machine in machines.machines {
@@ -42,7 +42,7 @@ pub async fn machine_new() -> anyhow::Result<()> {
     let client = ConfigManager::new()?.client()?;
 
     let machine = client
-        .create_machine(CreateMachineOptions::default())
+        .create_machine(CreateMachineRequest::default())
         .await?;
 
     println!(

--- a/rust/forevervm/src/commands/repl.rs
+++ b/rust/forevervm/src/commands/repl.rs
@@ -1,8 +1,11 @@
 use crate::config::ConfigManager;
 use colorize::AnsiColor;
-use forevervm_sdk::api::{
-    api_types::{ExecResultType, Instruction},
-    id_types::MachineName,
+use forevervm_sdk::{
+    api::{
+        api_types::{ExecResultType, Instruction},
+        id_types::MachineName,
+    },
+    client::CreateMachineOptions,
 };
 use rustyline::{error::ReadlineError, DefaultEditor};
 use std::time::Duration;
@@ -16,7 +19,9 @@ pub async fn machine_repl(
     let machine_name = if let Some(machine_name) = machine_name {
         machine_name
     } else {
-        let machine = client.create_machine().await?;
+        let machine = client
+            .create_machine(CreateMachineOptions::default())
+            .await?;
         machine.machine_name
     };
 

--- a/rust/forevervm/src/commands/repl.rs
+++ b/rust/forevervm/src/commands/repl.rs
@@ -1,11 +1,9 @@
 use crate::config::ConfigManager;
 use colorize::AnsiColor;
-use forevervm_sdk::{
-    api::{
-        api_types::{ExecResultType, Instruction},
-        id_types::MachineName,
-    },
-    client::CreateMachineOptions,
+use forevervm_sdk::api::{
+    api_types::{ExecResultType, Instruction},
+    http_api::CreateMachineRequest,
+    id_types::MachineName,
 };
 use rustyline::{error::ReadlineError, DefaultEditor};
 use std::time::Duration;
@@ -20,7 +18,7 @@ pub async fn machine_repl(
         machine_name
     } else {
         let machine = client
-            .create_machine(CreateMachineOptions::default())
+            .create_machine(CreateMachineRequest::default())
             .await?;
         machine.machine_name
     };


### PR DESCRIPTION
This adds support for arbitrary tag metadata on machines, which can be used for filtering in a "list machines" query.

This will be a draft PR until support lands in the server.