### PR TITLE
Add support for listing tags in the Rust client/sdk

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -497,7 +497,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "forevervm"
-version = "0.1.29"
+version = "0.1.30"
 dependencies = [
  "anyhow",
  "chrono",
@@ -516,7 +516,7 @@ dependencies = [
 
 [[package]]
 name = "forevervm-sdk"
-version = "0.1.29"
+version = "0.1.30"
 dependencies = [
  "chrono",
  "futures-util",

--- a/rust/forevervm-sdk/src/api/api_types.rs
+++ b/rust/forevervm-sdk/src/api/api_types.rs
@@ -1,6 +1,7 @@
 use super::id_types::{InstructionSeq, MachineName};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
 pub struct ApiMachine {
@@ -9,6 +10,9 @@ pub struct ApiMachine {
     pub running: bool,
     pub has_pending_instruction: bool,
     pub expires_at: Option<DateTime<Utc>>,
+
+    #[serde(default)]
+    pub tags: HashMap<String, String>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]

--- a/rust/forevervm/src/commands/machine.rs
+++ b/rust/forevervm/src/commands/machine.rs
@@ -31,6 +31,9 @@ pub async fn machine_list() -> anyhow::Result<()> {
         println!("  Expires: {}", expires_at.b_yellow());
         println!("  Status:  {}", status.b_yellow());
         println!("  Running: {}", machine.running.to_string().b_yellow());
+        for (key, value) in machine.tags.into_iter() {
+            println!("  Tag: {} = {}", key.b_yellow(), value.b_yellow());
+        }
         println!();
     }
 


### PR DESCRIPTION
The server does not support outputting these yet, but we need to add it here before we can write a test for the server.