### PR TITLE
allow tags to be omitted on requests

### DIFF
--- a/python/sdk/uv.lock
+++ b/python/sdk/uv.lock
@@ -34,7 +34,7 @@ wheels = [
 
 [[package]]
 name = "forevervm-sdk"
-version = "0.1.28"
+version = "0.1.30"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/rust/forevervm-sdk/src/api/http_api.rs
+++ b/rust/forevervm-sdk/src/api/http_api.rs
@@ -19,10 +19,12 @@ pub struct ListMachinesResponse {
 
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub struct CreateMachineRequest {
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub tags: HashMap<String, String>,
 }
 
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub struct ListMachinesRequest {
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub tags: HashMap<String, String>,
 }


### PR DESCRIPTION
This allows `tags` to be omitted in the JSON serialized version of a request. If omitted, it is deserialized as an empty hashmap.