### PR TITLE
Add memory limit to HTTP API

### DIFF
--- a/rust/forevervm-sdk/src/api/http_api.rs
+++ b/rust/forevervm-sdk/src/api/http_api.rs
@@ -21,6 +21,10 @@ pub struct ListMachinesResponse {
 pub struct CreateMachineRequest {
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub tags: HashMap<String, String>,
+
+    /// Memory size in MB. If not specified, a default value will be used.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub memory_mb: Option<u32>,
 }
 
 #[derive(Debug, Default, Serialize, Deserialize)]

--- a/rust/forevervm/src/commands/machine.rs
+++ b/rust/forevervm/src/commands/machine.rs
@@ -45,7 +45,10 @@ pub async fn machine_list(tags: std::collections::HashMap<String, String>) -> an
 pub async fn machine_new(tags: std::collections::HashMap<String, String>) -> anyhow::Result<()> {
     let client = ConfigManager::new()?.client()?;
 
-    let request = CreateMachineRequest { tags };
+    let request = CreateMachineRequest {
+        tags,
+        memory_mb: None,
+    };
     let machine = client.create_machine(request).await?;
 
     println!(


### PR DESCRIPTION
not implemented on the other side yet, but need to be exposed in the API types first.