### PR TITLE
Add memory limit option to CLI

### DIFF
--- a/rust/forevervm/src/commands/machine.rs
+++ b/rust/forevervm/src/commands/machine.rs
@@ -42,12 +42,15 @@ pub async fn machine_list(tags: std::collections::HashMap<String, String>) -> an
     Ok(())
 }
 
-pub async fn machine_new(tags: std::collections::HashMap<String, String>) -> anyhow::Result<()> {
+pub async fn machine_new(
+    tags: std::collections::HashMap<String, String>,
+    memory_mb: Option<u32>,
+) -> anyhow::Result<()> {
     let client = ConfigManager::new()?.client()?;
 
     let request = CreateMachineRequest {
         tags,
-        memory_mb: None,
+        memory_mb,
     };
     let machine = client.create_machine(request).await?;
 

--- a/rust/forevervm/src/main.rs
+++ b/rust/forevervm/src/main.rs
@@ -67,6 +67,10 @@ enum MachineCommands {
         /// Add tags to the machine in the format key=value
         #[arg(long = "tag", value_parser = parse_key_val, action = clap::ArgAction::Append)]
         tags: Option<Vec<(String, String)>>,
+        
+        /// Memory size in MB (if not specified, a default value will be used)
+        #[arg(long)]
+        memory_mb: Option<u32>,
     },
     /// List all machines
     List {
@@ -95,11 +99,11 @@ async fn main_inner() -> anyhow::Result<()> {
             whoami().await?;
         }
         Commands::Machine { command } => match command {
-            MachineCommands::New { tags } => {
+            MachineCommands::New { tags, memory_mb } => {
                 let tags_map = tags
                     .map(|tags| tags.into_iter().collect::<HashMap<String, String>>())
                     .unwrap_or_default();
-                machine_new(tags_map).await?;
+                machine_new(tags_map, memory_mb).await?;
             }
             MachineCommands::List { tags } => {
                 let tags_map = tags


### PR DESCRIPTION
This change adds support for specifying memory limits in megabytes when creating a new machine via the CLI. The API already had support for this parameter, but it was not exposed in the command-line interface.

🤖 Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude <noreply@anthropic.com>