### PR TITLE
Buffer streamed chunks from `stream-result` endpoint

### DIFF
--- a/javascript/sdk/src/index.ts
+++ b/javascript/sdk/src/index.ts
@@ -40,7 +40,8 @@ export class ForeverVM {
   async #get(path: string) {
     const response = await fetch(`${this.#baseUrl}${path}`, { headers: this.#headers })
     if (!response.ok) {
-      throw new Error(`HTTP error! status: ${response.status}`)
+      const text = await response.text().catch(() => 'Unknown error')
+      throw new Error(`HTTP ${response.status}: ${text}`)
     }
     return await response.json()
   }
@@ -48,7 +49,8 @@ export class ForeverVM {
   async *#getStream(path: string) {
     const response = await fetch(`${this.#baseUrl}${path}`, { headers: this.#headers })
     if (!response.ok) {
-      throw new Error(`HTTP error! status: ${response.status}`)
+      const text = await response.text().catch(() => 'Unknown error')
+      throw new Error(`HTTP ${response.status}: ${text}`)
     }
 
     if (!response.body) return
@@ -92,8 +94,10 @@ export class ForeverVM {
       body: body ? JSON.stringify(body) : undefined,
     })
     if (!response.ok) {
-      throw new Error(`HTTP error! status: ${response.status}`)
+      const text = await response.text().catch(() => 'Unknown error')
+      throw new Error(`HTTP ${response.status}: ${text}`)
     }
+
     return await response.json()
   }
 

--- a/javascript/sdk/src/index.ts
+++ b/javascript/sdk/src/index.ts
@@ -198,7 +198,7 @@ if (import.meta.vitest) {
     }
   })
 
-  test('execResultStream with image', async () => {
+  test('execResultStream with image', { timeout: 10000 }, async () => {
     const fvm = new ForeverVM({ token: FOREVERVM_TOKEN, baseUrl: FOREVERVM_API_BASE })
     const { machine_name } = await fvm.createMachine()
 

--- a/javascript/sdk/src/repl.ts
+++ b/javascript/sdk/src/repl.ts
@@ -299,7 +299,7 @@ if (import.meta.vitest) {
     expect(error).toMatch('ZeroDivisionError')
   })
 
-  test.sequential('reconnect', async () => {
+  test.sequential('reconnect', { timeout: 10000 }, async () => {
     const repl = new Repl({ token: FOREVERVM_TOKEN, baseUrl: FOREVERVM_API_BASE })
 
     await repl.exec('1 + 1').result

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -98,6 +98,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -518,6 +540,7 @@ dependencies = [
 name = "forevervm-sdk"
 version = "0.1.31"
 dependencies = [
+ "async-stream",
  "chrono",
  "futures-util",
  "regex",

--- a/rust/forevervm-sdk/Cargo.toml
+++ b/rust/forevervm-sdk/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 description = "foreverVM SDK. Allows you to start foreverVMs and run a REPL on them."
 
 [dependencies]
+async-stream = "0.3.6"
 chrono = { version = "0.4.39", features = ["serde"] }
 futures-util = "0.3.31"
 regex = "1.11.1"

--- a/rust/forevervm-sdk/tests/basic_sdk_tests.rs
+++ b/rust/forevervm-sdk/tests/basic_sdk_tests.rs
@@ -1,5 +1,6 @@
 use forevervm_sdk::api::api_types::Instruction;
 use forevervm_sdk::api::http_api::{CreateMachineRequest, ListMachinesRequest};
+use forevervm_sdk::api::protocol::MessageFromServer;
 use forevervm_sdk::{
     api::{api_types::ExecResultType, protocol::StandardOutputStream, token::ApiToken},
     client::ForeverVMClient,
@@ -88,6 +89,60 @@ async fn test_exec() {
 
 #[tokio::test]
 async fn test_exec_stream() {
+    let (api_base, token) = get_test_credentials();
+    let client = ForeverVMClient::new(api_base, token);
+
+    // Create machine and execute code
+    let machine = client
+        .create_machine(CreateMachineRequest::default())
+        .await
+        .expect("failed to create machine");
+    let code = "for i in range(10): print(i)\n'done'";
+
+    let result = client
+        .exec_instruction(
+            &machine.machine_name,
+            Instruction {
+                code: code.to_string(),
+                timeout_seconds: 10,
+            },
+        )
+        .await
+        .expect("exec failed");
+
+    let mut stream = client
+        .exec_result_stream(
+            &machine.machine_name,
+            result.instruction_seq.expect("instruction seq missing"),
+        )
+        .await
+        .expect("failed to get exec result");
+
+    let mut i = 0;
+    while let Some(msg) = stream.next().await {
+        match msg {
+            Ok(MessageFromServer::Output { chunk, .. }) => {
+                assert_eq!(chunk.data, format!("{}", i));
+                i += 1;
+            }
+            Ok(MessageFromServer::Result(chunk)) => {
+                assert_eq!(
+                    chunk.result.result,
+                    ExecResultType::Value {
+                        value: Some("'done'".to_string()),
+                        data: None
+                    }
+                );
+            }
+            _ => {
+                panic!("unexpected message");
+            }
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_exec_stream_image() {
     let (api_base, token) = get_test_credentials();
     let client = ForeverVMClient::new(api_base, token);
 

--- a/rust/forevervm-sdk/tests/basic_sdk_tests.rs
+++ b/rust/forevervm-sdk/tests/basic_sdk_tests.rs
@@ -4,6 +4,7 @@ use forevervm_sdk::{
     api::{api_types::ExecResultType, protocol::StandardOutputStream, token::ApiToken},
     client::ForeverVMClient,
 };
+use futures_util::StreamExt;
 use std::env;
 use url::Url;
 
@@ -83,6 +84,45 @@ async fn test_exec() {
             data: None
         }
     );
+}
+
+#[tokio::test]
+async fn test_exec_stream() {
+    let (api_base, token) = get_test_credentials();
+    let client = ForeverVMClient::new(api_base, token);
+
+    // Create machine and execute code
+    let machine = client
+        .create_machine(CreateMachineRequest::default())
+        .await
+        .expect("failed to create machine");
+    let code = "import matplotlib.pyplot as plt
+plt.plot([0, 1, 2], [0, 1, 2])
+plt.title('Simple Plot')
+plt.show()";
+
+    let result = client
+        .exec_instruction(
+            &machine.machine_name,
+            Instruction {
+                code: code.to_string(),
+                timeout_seconds: 10,
+            },
+        )
+        .await
+        .expect("exec failed");
+
+    let mut stream = client
+        .exec_result_stream(
+            &machine.machine_name,
+            result.instruction_seq.expect("instruction seq missing"),
+        )
+        .await
+        .expect("failed to get exec result");
+
+    while let Some(chunk) = stream.next().await {
+        assert!(chunk.is_ok(), "chunk should parse as JSON");
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
I ran into an issue with the `stream-result` endpoint where a single JSON output or result can end up split between multiple "chunks" in the HTTP response stream. One easy way to reproduce this is to stream back a result with an image, which we serialize to base 64; it ends up being split between two chunks, each of which is invalid JSON.

This PR circumvents that by processing each chunk "newline segment by newline segment".  There is a `value` that contains the current chunk, and a `buffer` that is assumed to contain all unfinished JSON from previous iterations. TL;DR:
1. The SDK waits to receive a chunk, which is put into `value`.
2. The SDK looks in `value` for the substring until the first newline.
3. If there is in fact a newline, it appends that substring to the buffer (if any), parses as JSON and yields it. Then it sets the `buffer` to an empty string and the `value` to the remaining text in the chunk after the substring. GOTO 2.
4. If there's no newline, it appends the substring to the buffer. Since the chunk is finished, it waits for the next chunk; GOTO 1.