### PR TITLE
Misc MCP improvements

### DIFF
--- a/javascript/mcp-server/README.md
+++ b/javascript/mcp-server/README.md
@@ -28,7 +28,7 @@ For other MCP clients, see [the docs](https://forevervm.com/docs/guides/foreverv
 
 ## Installing locally (for development only)
 
-In the MCP client, set the command to `npm` and the argumentsn to:
+In the MCP client, set the command to `npm` and the arguments to:
 
 ```json
 ["--prefix", "<path/to/this/directory>", "run", "start", "run"]

--- a/javascript/mcp-server/README.md
+++ b/javascript/mcp-server/README.md
@@ -23,3 +23,13 @@ Run the following command:
 ```bash
 npx forevervm-mcp install --claude
 ```
+
+For other MCP clients, see [the docs](https://forevervm.com/docs/guides/forevervm-mcp-server/).
+
+## Installing locally (for development only)
+
+In the MCP client, set the command to `npm` and the argumentsn to:
+
+```json
+["--prefix", "<path/to/this/directory>", "run", "start", "run"]
+```

--- a/javascript/mcp-server/src/index.ts
+++ b/javascript/mcp-server/src/index.ts
@@ -32,7 +32,7 @@ const ExecMachineSchema = z.object({
 const RUN_REPL_TOOL_NAME = 'run-python-in-repl'
 const CREATE_REPL_MACHINE_TOOL_NAME = 'create-python-repl'
 
-export function getForeverVMOptions(): ForeverVMOptions | null {
+export function getForeverVMOptions(): ForeverVMOptions {
   if (process.env.FOREVERVM_TOKEN) {
     return {
       token: process.env.FOREVERVM_TOKEN,
@@ -155,11 +155,6 @@ async function makeCreateMachineRequest(forevervmOptions: ForeverVMOptions): Pro
 // Start server
 async function runMCPServer() {
   const forevervmOptions = getForeverVMOptions()
-
-  if (!forevervmOptions) {
-    console.error('ForeverVM token not found. Please set up ForeverVM first.')
-    process.exit(1)
-  }
 
   const server = new Server(
     { name: 'forevervm', version: '1.0.0' },

--- a/javascript/mcp-server/src/install/index.ts
+++ b/javascript/mcp-server/src/install/index.ts
@@ -1,0 +1,34 @@
+import { getForeverVMOptions } from '../index.js'
+import { installForClaude } from './claude.js'
+import { installForGoose } from './goose.js'
+import { installForWindsurf } from './windsurf.js'
+
+export function installForeverVM(options: { claude: boolean; windsurf: boolean; goose: boolean }) {
+  const forevervmOptions = getForeverVMOptions()
+
+  if (!forevervmOptions?.token) {
+    console.error(
+      'ForeverVM token not found. Please set up ForeverVM first by running `npx forevervm login` or `npx forevervm signup`.',
+    )
+    process.exit(1)
+  }
+
+  if (!options.claude && !options.windsurf && !options.goose) {
+    console.log(
+      'Select at least one MCP client to install. Available options: --claude, --windsurf, --goose',
+    )
+    process.exit(1)
+  }
+
+  if (options.claude) {
+    installForClaude()
+  }
+
+  if (options.goose) {
+    installForGoose()
+  }
+
+  if (options.windsurf) {
+    installForWindsurf()
+  }
+}

--- a/javascript/sdk/src/index.ts
+++ b/javascript/sdk/src/index.ts
@@ -88,11 +88,16 @@ export class ForeverVM {
   }
 
   async #post(path: string, body?: object) {
-    const response = await fetch(`${this.#baseUrl}${path}`, {
-      method: 'POST',
-      headers: { ...this.#headers, 'Content-Type': 'application/json' },
-      body: body ? JSON.stringify(body) : undefined,
-    })
+    let response
+    try {
+      response = await fetch(`${this.#baseUrl}${path}`, {
+        method: 'POST',
+        headers: { ...this.#headers, 'Content-Type': 'application/json' },
+        body: body ? JSON.stringify(body) : undefined,
+      })
+    } catch (error) {
+      throw new Error(`Failed to fetch: ${error}`)
+    }
     if (!response.ok) {
       const text = await response.text().catch(() => 'Unknown error')
       throw new Error(`HTTP ${response.status}: ${text}`)

--- a/javascript/sdk/src/index.ts
+++ b/javascript/sdk/src/index.ts
@@ -96,7 +96,7 @@ export class ForeverVM {
         body: body ? JSON.stringify(body) : undefined,
       })
     } catch (error) {
-      throw new Error(`Failed to fetch: ${error}`)
+      throw new Error(`Failed to fetch: ${error.message}\n${error.stack}`)
     }
     if (!response.ok) {
       const text = await response.text().catch(() => 'Unknown error')

--- a/javascript/sdk/src/index.ts
+++ b/javascript/sdk/src/index.ts
@@ -96,7 +96,7 @@ export class ForeverVM {
         body: body ? JSON.stringify(body) : undefined,
       })
     } catch (error) {
-      throw new Error(`Failed to fetch: ${error.message}\n${error.stack}`)
+      throw new Error(`Failed to fetch: ${error}`)
     }
     if (!response.ok) {
       const text = await response.text().catch(() => 'Unknown error')

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -519,7 +519,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "forevervm"
-version = "0.1.31"
+version = "0.1.32"
 dependencies = [
  "anyhow",
  "chrono",
@@ -538,7 +538,7 @@ dependencies = [
 
 [[package]]
 name = "forevervm-sdk"
-version = "0.1.31"
+version = "0.1.32"
 dependencies = [
  "async-stream",
  "chrono",


### PR DESCRIPTION
- Adds a note pointing to the docs for other MCP clients
- Adds a note about installing for local development
- Reads server base URL from global forevervm CLI config if that's where the token comes from
- Adds endpoints for resources and prompts, even though we don't have any, which makes the logs cleaner (otherwise there is an error when the client hits them)
- When a request fails, we send an error message to the client instead of exiting
- Moves MCP installation-related code to a separate file